### PR TITLE
SPOC-210, SPOC-235: Provide upgrade path to 1.2.1, display version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 MODULE_big = lolor
 
 EXTENSION = lolor
-DATA = lolor--1.0.sql
+DATA = lolor--1.0.sql \
+	   lolor--1.0--1.2.1.sql
 PGFILEDESC = "lolor - drop in large objects replacement for logical replication"
 
 OBJS = src/lolor.o src/lolor_fsstubs.o src/lolor_inv_api.o src/lolor_largeobject.o

--- a/lolor--1.0--1.2.1.sql
+++ b/lolor--1.0--1.2.1.sql
@@ -1,0 +1,5 @@
+/* lolor--1.0--1.2.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION lolor" to load this file. \quit
+

--- a/lolor.control
+++ b/lolor.control
@@ -1,6 +1,6 @@
 # lolor extension
 comment = 'Large Objects support for logical replication'
-default_version = '1.0'
+default_version = '1.2.1'
 module_pathname = '$libdir/lolor'
 relocatable = false
 trusted = true


### PR DESCRIPTION
The original intent was to support Postgres 18. This is already supported on the main branch, so prepare for a new release, v1.2.1.

In the past, the SQL files were not maintained for v1.1 and v1.2, address for v1.2.1.

Also done-  SPOC-235: make sure the version is displayed properly. I tested a new install and upgrade scenarios and verified that `\dx` in `psql` displays the version properly.