### PR TITLE
Update module versions due to CVEs

### DIFF
--- a/tests/go/go.mod
+++ b/tests/go/go.mod
@@ -2,7 +2,7 @@ module lolor_tests
 
 go 1.23.9
 
-require github.com/jackc/pgx/v5 v5.5.5
+require github.com/jackc/pgx/v5 v5.7.6
 
 require (
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -10,9 +10,9 @@ require (
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
-	golang.org/x/crypto v0.20.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/crypto v0.40.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
 )

--- a/tests/junit/multinode/pom.xml
+++ b/tests/junit/multinode/pom.xml
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.19</version>
+            <version>42.2.29</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/junit/singlenode/pom.xml
+++ b/tests/junit/singlenode/pom.xml
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.19</version>
+            <version>42.2.29</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The reported CVEs are for modules that are only used in tests, so no worries in terms of affecting lolor itself.