### PR TITLE
SPOC-470: [Security] [Codacy] Triage security issues in lolor

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout lolor
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.ref }}
 
@@ -28,10 +28,10 @@ jobs:
         sudo chmod -R a+w ${GITHUB_WORKSPACE}
 
     - name: Set up Docker
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
     - name: Set up docker-compose
-      uses: docker/setup-compose-action@v1
+      uses: docker/setup-compose-action@2fe291b7677a45ee1269ec56a42604c143505e7e # v1
 
     - name: Build and run docker images
       run: |
@@ -57,7 +57,7 @@ jobs:
         grep -Eq "FAIL|ERROR" tests/out.txt && exit 1 || exit 0
 
     - name: Upload Log File as Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: latest-log-${{ matrix.pgver }}
         path: tests/out.txt

--- a/src/lolor_fsstubs.c
+++ b/src/lolor_fsstubs.c
@@ -489,7 +489,7 @@ lo_import_internal(text *filename, Oid lobjOid)
 	 */
 	lobj = lolor_inv_open(oid, INV_WRITE, CurrentMemoryContext);
 
-	while ((nbytes = read(fd, buf, BUFSIZE)) > 0)
+	while ((nbytes = read(fd, buf, BUFSIZE)) > 0)	/* Flawfinder: ignore */
 	{
 		tmp = lolor_inv_write(lobj, buf, nbytes);
 		Assert(tmp == nbytes);
@@ -543,7 +543,7 @@ lolor_lo_export(PG_FUNCTION_ARGS)
 	 * world-writable export files doesn't seem wise.
 	 */
 	text_to_cstring_buffer(filename, fnamebuf, sizeof(fnamebuf));
-	oumask = umask(S_IWGRP | S_IWOTH);
+	oumask = umask(S_IWGRP | S_IWOTH);	/* Flawfinder: ignore — matches core be-fsstubs.c intentionally */
 	PG_TRY();
 	{
 		fd = OpenTransientFilePerm(fnamebuf, O_CREAT | O_WRONLY | O_TRUNC | PG_BINARY,
@@ -551,7 +551,7 @@ lolor_lo_export(PG_FUNCTION_ARGS)
 	}
 	PG_FINALLY();
 	{
-		umask(oumask);
+		umask(oumask);	/* Flawfinder: ignore — restoring previous mask */
 	}
 	PG_END_TRY();
 	if (fd < 0)

--- a/src/lolor_inv_api.c
+++ b/src/lolor_inv_api.c
@@ -560,6 +560,7 @@ lolor_inv_read(LargeObjectDesc *obj_desc, char *buf, int nbytes)
 			{
 				n = len - off;
 				n = (n <= (nbytes - nread)) ? n : (nbytes - nread);
+				Assert(n > 0 && n <= nbytes - nread && n <= len - off);
 				memcpy(buf + nread, VARDATA(datafield) + off, n);
 				nread += n;
 				obj_desc->offset += n;
@@ -678,6 +679,7 @@ lolor_inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			 * First, load old data into workbuf
 			 */
 			getdatafield(olddata, &datafield, &len, &pfreeit);
+			Assert(len >= 0 && len <= LOBLKSIZE);	/* validated by getdatafield() */
 			memcpy(workb, VARDATA(datafield), len);
 			if (pfreeit)
 				pfree(datafield);
@@ -694,6 +696,8 @@ lolor_inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			 */
 			n = LOBLKSIZE - off;
 			n = (n <= (nbytes - nwritten)) ? n : (nbytes - nwritten);
+			Assert(n > 0 && off + n <= LOBLKSIZE);	/* destination fits in workbuf page */
+			Assert(n <= nbytes - nwritten);			/* source fits in caller's buffer */
 			memcpy(workb + off, buf + nwritten, n);
 			nwritten += n;
 			obj_desc->offset += n;
@@ -739,6 +743,8 @@ lolor_inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			 */
 			n = LOBLKSIZE - off;
 			n = (n <= (nbytes - nwritten)) ? n : (nbytes - nwritten);
+			Assert(n > 0 && off + n <= LOBLKSIZE);	/* destination fits in workbuf page */
+			Assert(n <= nbytes - nwritten);			/* source fits in caller's buffer */
 			memcpy(workb + off, buf + nwritten, n);
 			nwritten += n;
 			obj_desc->offset += n;
@@ -863,6 +869,7 @@ lolor_inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 		bool		pfreeit;
 
 		getdatafield(olddata, &datafield, &pagelen, &pfreeit);
+		Assert(pagelen >= 0 && pagelen <= LOBLKSIZE);	/* validated by getdatafield() */
 		memcpy(workb, VARDATA(datafield), pagelen);
 		if (pfreeit)
 			pfree(datafield);


### PR DESCRIPTION
## Address Codacy security warnings in lolor (spoc-470)

Two categories of findings reported by Codacy's Flawfinder analyser are resolved across `.github/workflows/workflow.yml`, `src/lolor_fsstubs.c`, and `src/lolor_inv_api.c`.

### GitHub Actions: unpinned third-party actions (commit 0647af4)

All four actions in the CI workflow were referenced by mutable version tags (`@v2`, `@v4`, etc.). A compromised upstream repository could silently redirect a tag to malicious code. Each action is now pinned to the full 40-character commit SHA that the tag currently resolves to, with the original tag retained as an inline comment for readability:

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `docker/setup-buildx-action` | v2 | `885d1462b80bc1c1c7f0b00334ad271f09369c55` |
| `docker/setup-compose-action` | v1 | `2fe291b7677a45ee1269ec56a42604c143505e7e` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |

### Flawfinder warnings in C sources (commit 3872cb9)

Codacy runs Flawfinder as one of its four C/C++ analysers. The findings fall into two groups:

**False positives — suppressed with `Flawfinder: ignore`:**

- `read(fd, buf, BUFSIZE)` in `lo_import_internal`: the count argument is exactly `sizeof(buf)`; `nbytes` is always ≤ `BUFSIZE`. No overrun is possible (CWE-120, CWE-20).
- `umask(S_IWGRP | S_IWOTH)` in `lo_export`: value `0022` is kept intentionally in sync with PostgreSQL core `be-fsstubs.c`. Changing it unilaterally without a policy decision would create an unexplained behavioural divergence from native large objects (CWE-732).
- `umask(oumask)` restore call in `PG_FINALLY`: the tool flags every `umask()` call regardless of argument; this one simply restores the prior mask (CWE-732).

**Bounds not visible to the analyser — resolved with `Assert()`:**

`Assert()` is preferred over suppression here: it documents the invariant at the call site, catches future regressions in debug builds, and costs nothing in release builds.

- `lolor_inv_read`: `n` is clamped to `min(len - off, nbytes - nread)` before the `memcpy`; assertion makes both source and destination bounds explicit.
- `lolor_inv_write` (two sites, existing-page and new-page paths): `len` is validated by `getdatafield()` to be in `[0, LOBLKSIZE]`; `n` is clamped to `min(LOBLKSIZE - off, nbytes - nwritten)`. Assertions cover destination-page capacity and source-buffer capacity at each site.
- `lolor_inv_truncate`: same `getdatafield()` guarantee applies to `pagelen`.
