### PR TITLE
Zero downtime migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 *.so
 *.bc
 *.o
+results/
+tmp_check/
+log/
+regression.diffs
+regression.out
+delete_old_cluster.sh
+

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DATA = lolor--1.0.sql \
 	   lolor--1.2.2--1.3.0.sql
 PGFILEDESC = "lolor - drop in large objects replacement for logical replication"
 
-OBJS = src/lolor.o src/lolor_fsstubs.o src/lolor_inv_api.o src/lolor_largeobject.o
+OBJS = src/lolor.o src/lolor_fsstubs.o src/lolor_inv_api.o src/lolor_largeobject.o src/oldloutils.o
 
 REGRESS = lolor
 TAP_TESTS = 1

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DATA = lolor--1.0.sql \
 	   lolor--1.2.2--1.3.0.sql
 PGFILEDESC = "lolor - drop in large objects replacement for logical replication"
 
-OBJS = src/lolor.o src/lolor_fsstubs.o src/lolor_inv_api.o src/lolor_largeobject.o src/oldloutils.o
+OBJS = src/lolor.o src/lolor_fsstubs.o src/lolor_inv_api.o src/lolor_largeobject.o src/oldloutils.o src/lolor_utility.o
 
 REGRESS = lolor
 TAP_TESTS = 1

--- a/expected/lolor.out
+++ b/expected/lolor.out
@@ -1066,19 +1066,17 @@ SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oi
 
 -- Grant ALL PRIVILEGES
 GRANT ALL PRIVILEGES ON LARGE OBJECT 4001 TO lolor_test_user2;
-WARNING:  no privileges were granted for "large object 4001"
-SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
- has_acl 
----------
+SELECT lomacl::text LIKE '%lolor_test_user2=rw/%' AS has_all_privs FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ has_all_privs 
+---------------
  t
 (1 row)
 
 -- Revoke ALL PRIVILEGES
 REVOKE ALL PRIVILEGES ON LARGE OBJECT 4001 FROM lolor_test_user2;
-WARNING:  no privileges could be revoked for "large object 4001"
-SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
- has_acl 
----------
+SELECT lomacl::text NOT LIKE '%lolor_test_user2%' AS revoked_all FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ revoked_all 
+-------------
  t
 (1 row)
 
@@ -1095,6 +1093,11 @@ DROP ROLE lolor_test_user1;
 ERROR:  role "lolor_test_user1" cannot be dropped because some objects depend on it
 DROP ROLE lolor_test_user2;
 ERROR:  role "lolor_test_user2" cannot be dropped because some objects depend on it
+-- Test security: non-superuser should be denied from cleanup_dependencies
+SET ROLE lolor_test_user1;
+SELECT lolor.cleanup_dependencies();
+ERROR:  permission denied for schema lolor at character 8
+RESET ROLE;
 -- Now transfer ownership back to current user and revoke privileges from user2
 ALTER LARGE OBJECT 4001 OWNER TO CURRENT_USER;
 ALTER LARGE OBJECT 4002 OWNER TO CURRENT_USER;
@@ -1114,11 +1117,24 @@ SELECT lolor.cleanup_dependencies() >= 2 AS cleaned_deps;
 -- Now dropping the roles should succeed!
 DROP ROLE lolor_test_user1;
 DROP ROLE lolor_test_user2;
--- Cleanup
+-- Verify DeleteComments removes comment on lo_unlink
+COMMENT ON LARGE OBJECT 4001 IS 'Comment before unlink';
+SELECT count(*) FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
+ count 
+-------
+     1
+(1 row)
+
 SELECT lo_unlink(4001);
  lo_unlink 
 -----------
          1
+(1 row)
+
+SELECT count(*) FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
+ count 
+-------
+     0
 (1 row)
 
 SELECT lo_unlink(4002);
@@ -1365,6 +1381,90 @@ SELECT lolor.lolor_migrate(0);
  lolor_migrate 
 ---------------
              0
+(1 row)
+
+-- 5. Negative batch size validation
+SELECT lolor.migrate(-1);
+ERROR:  lolor.migrate() batch size must not be negative
+-- 6. Empty (0-page) large object migrated by reverse mode
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_create(5030);
+ lo_create 
+-----------
+      5030
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+SELECT lolor.migrate(strict_from_end_to_start => true);
+ migrate 
+---------
+       1
+(1 row)
+
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5030;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5030;
+ count 
+-------
+     1
+(1 row)
+
+SELECT lo_unlink(5030);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+-- 7. Disabled state passthrough for utility commands
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_create(5031);
+ lo_create 
+-----------
+      5031
+(1 row)
+
+ALTER LARGE OBJECT 5031 OWNER TO CURRENT_ROLE;
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5031;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5031;
+ count 
+-------
+     0
+(1 row)
+
+SELECT lo_unlink(5031);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
 (1 row)
 
 -- Cleanup

--- a/expected/lolor.out
+++ b/expected/lolor.out
@@ -115,6 +115,12 @@ SELECT lo_close(:fd);
 (1 row)
 
 END;
+SELECT lo_unlink(:loid);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
 --
 -- lo_tell: verify cursor position before and after a write.
 -- Expected: position 0 before write, position 11 after writing 11 bytes;
@@ -175,6 +181,12 @@ SELECT lo_close(:fd);
 (1 row)
 
 END;
+SELECT lo_unlink(:loid);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
 --
 -- lo_truncate: truncate to 10 bytes, verify only the prefix survives.
 -- Expected: only "0123456789" readable after truncation.
@@ -216,6 +228,12 @@ SELECT lo_close(:fd);
 (1 row)
 
 END;
+SELECT lo_unlink(:loid);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
 DROP EXTENSION lolor;
 NOTICE:  migrated 1 large object(s) from lolor to native storage
 -- Check extension upgrade
@@ -309,14 +327,33 @@ SELECT lolor.enable();
  t
 (1 row)
 
-SELECT lo_open(2, 262144); -- 'not found' ERROR
-ERROR:  large object 2 does not exist
+BEGIN;
+SELECT lo_open(2, 262144) AS fd \gset
+SELECT convert_from(loread(:fd, 1024), 'UTF8'); -- OK, see the native object
+                    convert_from                    
+----------------------------------------------------
+ Example large object stored in built-in LO storage
+(1 row)
+
+SELECT lo_close(:fd);
+ lo_close 
+----------
+        0
+(1 row)
+
+END;
 BEGIN;
 SELECT lo_open(1, 262144) AS fd \gset
 SELECT convert_from(loread(:fd, 1024), 'UTF8'); -- OK, see the object
                   convert_from                   
 -------------------------------------------------
  Example large object stored in lolor LO storage
+(1 row)
+
+SELECT lo_close(:fd);
+ lo_close 
+----------
+        0
 (1 row)
 
 END;
@@ -638,10 +675,11 @@ SELECT lolor.disable();
  t
 (1 row)
 
-SELECT lo_create(:'drop_conflict_oid');
- lo_create 
------------
-    268385
+SELECT lo_create(:'drop_conflict_oid') AS created_drop_oid \gset
+SELECT :'created_drop_oid' = :'drop_conflict_oid' AS oid_matches;
+ oid_matches 
+-------------
+ t
 (1 row)
 
 SELECT lolor.enable();
@@ -689,3 +727,223 @@ SELECT lolor.enable();
 -- Now DROP should succeed
 DROP EXTENSION lolor;
 NOTICE:  migrated 1 large object(s) from lolor to native storage
+--
+-- Zero-downtime migration: transparent reading and on-the-fly migration
+--
+CREATE EXTENSION lolor;
+-- 1. Create a native large object while lolor is disabled
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(3001, 'Native LO data for zero-downtime reading test');
+ lo_from_bytea 
+---------------
+          3001
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+-- 2. Verify reading via lo_get and lo_get_fragment works transparently with lolor enabled
+SELECT convert_from(lo_get(3001), 'UTF8');
+                 convert_from                  
+-----------------------------------------------
+ Native LO data for zero-downtime reading test
+(1 row)
+
+SELECT convert_from(lo_get(3001, 7, 7), 'UTF8');
+ convert_from 
+--------------
+ LO data
+(1 row)
+
+-- 3. Verify reading via lo_open, lo_lseek, lo_tell, loread, lo_close
+BEGIN;
+SELECT lo_open(3001, 262144) AS fd \gset
+SELECT lo_tell(:fd);
+ lo_tell 
+---------
+       0
+(1 row)
+
+SELECT lo_lseek(:fd, 7, 0);
+ lo_lseek 
+----------
+        7
+(1 row)
+
+SELECT lo_tell(:fd);
+ lo_tell 
+---------
+       7
+(1 row)
+
+SELECT convert_from(loread(:fd, 7), 'UTF8');
+ convert_from 
+--------------
+ LO data
+(1 row)
+
+SELECT lo_close(:fd);
+ lo_close 
+----------
+        0
+(1 row)
+
+END;
+-- 4. Verify object is still in native storage (reads do not migrate)
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3001;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3001;
+ count 
+-------
+     0
+(1 row)
+
+-- 5. On-the-fly migration on write (lo_put)
+SELECT lo_put(3001, 0, 'MODIFIED');
+ lo_put 
+--------
+ 
+(1 row)
+
+-- Now object 3001 must be in lolor storage and gone from native storage!
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3001;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3001;
+ count 
+-------
+     1
+(1 row)
+
+SELECT convert_from(lo_get(3001), 'UTF8');
+                 convert_from                  
+-----------------------------------------------
+ MODIFIEDO data for zero-downtime reading test
+(1 row)
+
+-- 6. On-the-fly migration on write via lo_open(INV_WRITE) + lowrite
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(3002, 'Native LO for write migration test');
+ lo_from_bytea 
+---------------
+          3002
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+BEGIN;
+SELECT lo_open(3002, x'60000'::int) AS fd \gset
+SELECT lowrite(:fd, 'MIGRATED');
+ lowrite 
+---------
+       8
+(1 row)
+
+SELECT lo_close(:fd);
+ lo_close 
+----------
+        0
+(1 row)
+
+END;
+-- Must be in lolor storage and gone from native storage
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3002;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3002;
+ count 
+-------
+     1
+(1 row)
+
+SELECT convert_from(lo_get(3002), 'UTF8');
+            convert_from            
+------------------------------------
+ MIGRATEDO for write migration test
+(1 row)
+
+-- 7. Transparent lo_unlink of native object
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(3003, 'Native LO to be unlinked');
+ lo_from_bytea 
+---------------
+          3003
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3003;
+ count 
+-------
+     1
+(1 row)
+
+SELECT lo_unlink(3003);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3003;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3003;
+ count 
+-------
+     0
+(1 row)
+
+-- Cleanup migrated objects
+SELECT lo_unlink(3001);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(3002);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+DROP EXTENSION lolor;
+NOTICE:  no lolor large objects to migrate

--- a/expected/lolor.out
+++ b/expected/lolor.out
@@ -1129,3 +1129,304 @@ SELECT lo_unlink(4002);
 
 DROP EXTENSION lolor;
 NOTICE:  no lolor large objects to migrate
+--
+-- lolor.migrate(): incremental batch migration
+--
+CREATE EXTENSION lolor;
+-- Ensure any leftover native large objects are migrated first
+SELECT lolor.migrate() >= 0 AS clean_start;
+ clean_start 
+-------------
+ t
+(1 row)
+
+-- 1. Create 5 native large objects
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(5001, 'Batch migration 1');
+ lo_from_bytea 
+---------------
+          5001
+(1 row)
+
+SELECT lo_from_bytea(5002, 'Batch migration 2');
+ lo_from_bytea 
+---------------
+          5002
+(1 row)
+
+SELECT lo_from_bytea(5003, 'Batch migration 3');
+ lo_from_bytea 
+---------------
+          5003
+(1 row)
+
+SELECT lo_from_bytea(5004, 'Batch migration 4');
+ lo_from_bytea 
+---------------
+          5004
+(1 row)
+
+SELECT lo_from_bytea(5005, 'Batch migration 5');
+ lo_from_bytea 
+---------------
+          5005
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+-- Check initial distribution
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+ native_cnt 
+------------
+          5
+(1 row)
+
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+ lolor_cnt 
+-----------
+         0
+(1 row)
+
+-- Migrate batch of 2
+SELECT lolor.migrate(2);
+ migrate 
+---------
+       2
+(1 row)
+
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+ native_cnt 
+------------
+          3
+(1 row)
+
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+ lolor_cnt 
+-----------
+         2
+(1 row)
+
+-- Migrate all remaining
+SELECT lolor.migrate();
+ migrate 
+---------
+       3
+(1 row)
+
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+ native_cnt 
+------------
+          0
+(1 row)
+
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+ lolor_cnt 
+-----------
+         5
+(1 row)
+
+-- Calling again returns 0
+SELECT lolor.migrate();
+ migrate 
+---------
+       0
+(1 row)
+
+-- 2. strict_from_end_to_start: reverse physical scan
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(5011, 'End to start 1');
+ lo_from_bytea 
+---------------
+          5011
+(1 row)
+
+SELECT lo_from_bytea(5012, 'End to start 2');
+ lo_from_bytea 
+---------------
+          5012
+(1 row)
+
+SELECT lo_from_bytea(5013, 'End to start 3');
+ lo_from_bytea 
+---------------
+          5013
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+-- Reverse scan should pick 5013 first (written last at physical end)
+SELECT lolor.migrate(1, strict_from_end_to_start => true);
+ migrate 
+---------
+       1
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5013;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5013;
+ count 
+-------
+     0
+(1 row)
+
+-- Migrate remaining objects with reverse scan
+SELECT lolor.migrate(strict_from_end_to_start => true);
+ migrate 
+---------
+       2
+(1 row)
+
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
+ native_cnt 
+------------
+          0
+(1 row)
+
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
+ lolor_cnt 
+-----------
+         3
+(1 row)
+
+-- 3. run_vacuum and procedure call
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(5021, 'Vacuum test 1');
+ lo_from_bytea 
+---------------
+          5021
+(1 row)
+
+SELECT lo_from_bytea(5022, 'Vacuum test 2');
+ lo_from_bytea 
+---------------
+          5022
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+-- Function with run_vacuum => true
+SELECT lolor.migrate(1, run_vacuum => true);
+ migrate 
+---------
+       1
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5021;
+ count 
+-------
+     1
+(1 row)
+
+SELECT lolor.migrate(1, run_vacuum => true);
+ migrate 
+---------
+       1
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5022;
+ count 
+-------
+     1
+(1 row)
+
+-- 4. Alias test: lolor.lolor_migrate
+SELECT lolor.lolor_migrate(0);
+ lolor_migrate 
+---------------
+             0
+(1 row)
+
+-- Cleanup
+SELECT lo_unlink(5001);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5002);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5003);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5004);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5005);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5011);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5012);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5013);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5021);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(5022);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+DROP EXTENSION lolor;
+NOTICE:  migrated 6 large object(s) from lolor to native storage

--- a/expected/lolor.out
+++ b/expected/lolor.out
@@ -1150,7 +1150,7 @@ NOTICE:  no lolor large objects to migrate
 --
 CREATE EXTENSION lolor;
 -- Ensure any leftover native large objects are migrated first
-SELECT lolor.migrate() >= 0 AS clean_start;
+SELECT lolor.lolor_migrate() >= 0 AS clean_start;
  clean_start 
 -------------
  t
@@ -1213,10 +1213,10 @@ SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEE
 (1 row)
 
 -- Migrate batch of 2
-SELECT lolor.migrate(2);
- migrate 
----------
-       2
+CALL lolor.migrate(2);
+ migrated 
+----------
+        2
 (1 row)
 
 SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
@@ -1232,10 +1232,10 @@ SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEE
 (1 row)
 
 -- Migrate all remaining
-SELECT lolor.migrate();
- migrate 
----------
-       3
+CALL lolor.migrate();
+ migrated 
+----------
+        3
 (1 row)
 
 SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
@@ -1251,10 +1251,10 @@ SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEE
 (1 row)
 
 -- Calling again returns 0
-SELECT lolor.migrate();
- migrate 
----------
-       0
+CALL lolor.migrate();
+ migrated 
+----------
+        0
 (1 row)
 
 -- 2. strict_from_end_to_start: reverse physical scan
@@ -1289,10 +1289,10 @@ SELECT lolor.enable();
 (1 row)
 
 -- Reverse scan should pick 5013 first (written last at physical end)
-SELECT lolor.migrate(1, strict_from_end_to_start => true);
- migrate 
----------
-       1
+CALL lolor.migrate(1, strict_from_end_to_start => true);
+ migrated 
+----------
+        1
 (1 row)
 
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5013;
@@ -1308,10 +1308,10 @@ SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5013;
 (1 row)
 
 -- Migrate remaining objects with reverse scan
-SELECT lolor.migrate(strict_from_end_to_start => true);
- migrate 
----------
-       2
+CALL lolor.migrate(strict_from_end_to_start => true);
+ migrated 
+----------
+        2
 (1 row)
 
 SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
@@ -1351,11 +1351,11 @@ SELECT lolor.enable();
  t
 (1 row)
 
--- Function with run_vacuum => true
-SELECT lolor.migrate(1, run_vacuum => true);
- migrate 
----------
-       1
+-- Procedure with run_vacuum => true
+CALL lolor.migrate(1, run_vacuum => true);
+ migrated 
+----------
+        1
 (1 row)
 
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5021;
@@ -1364,10 +1364,10 @@ SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5021;
      1
 (1 row)
 
-SELECT lolor.migrate(1, run_vacuum => true);
- migrate 
----------
-       1
+CALL lolor.migrate(1, run_vacuum => true);
+ migrated 
+----------
+        1
 (1 row)
 
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5022;
@@ -1376,7 +1376,14 @@ SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5022;
      1
 (1 row)
 
--- 4. Alias test: lolor.lolor_migrate
+-- Dedicated vacuum helper test
+SELECT lolor.vacuum_native_storage();
+ vacuum_native_storage 
+-----------------------
+ 
+(1 row)
+
+-- 4. Core function test: lolor.lolor_migrate
 SELECT lolor.lolor_migrate(0);
  lolor_migrate 
 ---------------
@@ -1384,7 +1391,7 @@ SELECT lolor.lolor_migrate(0);
 (1 row)
 
 -- 5. Negative batch size validation
-SELECT lolor.migrate(-1);
+CALL lolor.migrate(-1);
 ERROR:  lolor.migrate() batch size must not be negative
 -- 6. Empty (0-page) large object migrated by reverse mode
 SELECT lolor.disable();
@@ -1405,10 +1412,10 @@ SELECT lolor.enable();
  t
 (1 row)
 
-SELECT lolor.migrate(strict_from_end_to_start => true);
- migrate 
----------
-       1
+CALL lolor.migrate(strict_from_end_to_start => true);
+ migrated 
+----------
+        1
 (1 row)
 
 SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5030;

--- a/expected/lolor.out
+++ b/expected/lolor.out
@@ -947,3 +947,185 @@ SELECT lo_unlink(3002);
 
 DROP EXTENSION lolor;
 NOTICE:  no lolor large objects to migrate
+--
+-- ProcessUtility hook: ALTER, COMMENT, GRANT, REVOKE on LARGE OBJECT
+--
+CREATE EXTENSION lolor;
+-- Create test roles
+CREATE ROLE lolor_test_user1;
+CREATE ROLE lolor_test_user2;
+-- Create large objects (one in lolor, one native)
+SELECT lo_from_bytea(4001, 'Lolor LO for utility tests');
+ lo_from_bytea 
+---------------
+          4001
+(1 row)
+
+SELECT lolor.disable();
+ disable 
+---------
+ t
+(1 row)
+
+SELECT lo_from_bytea(4002, 'Native LO for utility tests');
+ lo_from_bytea 
+---------------
+          4002
+(1 row)
+
+SELECT lolor.enable();
+ enable 
+--------
+ t
+(1 row)
+
+-- 1. COMMENT ON LARGE OBJECT
+-- Set comment on lolor object
+COMMENT ON LARGE OBJECT 4001 IS 'Test comment on lolor LO';
+SELECT description FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
+       description        
+--------------------------
+ Test comment on lolor LO
+(1 row)
+
+-- Set comment on native object
+COMMENT ON LARGE OBJECT 4002 IS 'Test comment on native LO';
+SELECT description FROM pg_description WHERE objoid = 4002 AND classoid = 'pg_largeobject'::regclass;
+        description        
+---------------------------
+ Test comment on native LO
+(1 row)
+
+-- Remove comment by setting to NULL
+COMMENT ON LARGE OBJECT 4001 IS NULL;
+SELECT description FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
+ description 
+-------------
+(0 rows)
+
+-- Error on non-existent object
+COMMENT ON LARGE OBJECT 999999 IS 'Should fail';
+ERROR:  large object 999999 does not exist
+-- 2. ALTER LARGE OBJECT ... OWNER TO
+-- Alter owner of lolor object
+ALTER LARGE OBJECT 4001 OWNER TO lolor_test_user1;
+SELECT lomowner = (SELECT oid FROM pg_roles WHERE rolname = 'lolor_test_user1') AS is_user1_owner
+  FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ is_user1_owner 
+----------------
+ t
+(1 row)
+
+-- Alter owner of native object: should migrate on-the-fly to lolor storage
+ALTER LARGE OBJECT 4002 OWNER TO lolor_test_user1;
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 4002;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 4002;
+ count 
+-------
+     1
+(1 row)
+
+SELECT lomowner = (SELECT oid FROM pg_roles WHERE rolname = 'lolor_test_user1') AS is_user1_owner
+  FROM lolor.pg_largeobject_metadata WHERE oid = 4002;
+ is_user1_owner 
+----------------
+ t
+(1 row)
+
+-- Verify comment on 4002 is still preserved after migration
+SELECT description FROM pg_description WHERE objoid = 4002 AND classoid = 'pg_largeobject'::regclass;
+        description        
+---------------------------
+ Test comment on native LO
+(1 row)
+
+-- Error on non-existent object
+ALTER LARGE OBJECT 999999 OWNER TO lolor_test_user1;
+ERROR:  large object 999999 does not exist
+-- 3. GRANT and REVOKE on LARGE OBJECT
+-- Grant SELECT and UPDATE to lolor_test_user2
+GRANT SELECT, UPDATE ON LARGE OBJECT 4001 TO lolor_test_user2;
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ has_acl 
+---------
+ t
+(1 row)
+
+-- Revoke UPDATE from lolor_test_user2
+REVOKE UPDATE ON LARGE OBJECT 4001 FROM lolor_test_user2;
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ has_acl 
+---------
+ t
+(1 row)
+
+-- Grant ALL PRIVILEGES
+GRANT ALL PRIVILEGES ON LARGE OBJECT 4001 TO lolor_test_user2;
+WARNING:  no privileges were granted for "large object 4001"
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ has_acl 
+---------
+ t
+(1 row)
+
+-- Revoke ALL PRIVILEGES
+REVOKE ALL PRIVILEGES ON LARGE OBJECT 4001 FROM lolor_test_user2;
+WARNING:  no privileges could be revoked for "large object 4001"
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+ has_acl 
+---------
+ t
+(1 row)
+
+-- Error on non-existent object
+GRANT SELECT ON LARGE OBJECT 999999 TO lolor_test_user2;
+ERROR:  large object 999999 does not exist
+REVOKE SELECT ON LARGE OBJECT 999999 FROM lolor_test_user2;
+ERROR:  large object 999999 does not exist
+-- 4. Dependency tracking and lolor.cleanup_dependencies()
+-- Grant privilege to lolor_test_user2 to record dependency
+GRANT SELECT ON LARGE OBJECT 4001 TO lolor_test_user2;
+-- Dropping user1 or user2 should fail because they have dependencies
+DROP ROLE lolor_test_user1;
+ERROR:  role "lolor_test_user1" cannot be dropped because some objects depend on it
+DROP ROLE lolor_test_user2;
+ERROR:  role "lolor_test_user2" cannot be dropped because some objects depend on it
+-- Now transfer ownership back to current user and revoke privileges from user2
+ALTER LARGE OBJECT 4001 OWNER TO CURRENT_USER;
+ALTER LARGE OBJECT 4002 OWNER TO CURRENT_USER;
+REVOKE SELECT ON LARGE OBJECT 4001 FROM lolor_test_user2;
+-- Attempting to drop role directly still fails before cleanup
+DROP ROLE lolor_test_user1;
+ERROR:  role "lolor_test_user1" cannot be dropped because some objects depend on it
+DROP ROLE lolor_test_user2;
+ERROR:  role "lolor_test_user2" cannot be dropped because some objects depend on it
+-- Run lolor.cleanup_dependencies()
+SELECT lolor.cleanup_dependencies() >= 2 AS cleaned_deps;
+ cleaned_deps 
+--------------
+ t
+(1 row)
+
+-- Now dropping the roles should succeed!
+DROP ROLE lolor_test_user1;
+DROP ROLE lolor_test_user2;
+-- Cleanup
+SELECT lo_unlink(4001);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_unlink(4002);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+DROP EXTENSION lolor;
+NOTICE:  no lolor large objects to migrate

--- a/lolor--1.2.2--1.3.0.sql
+++ b/lolor--1.2.2--1.3.0.sql
@@ -373,3 +373,36 @@ RETURNS integer
 AS 'MODULE_PATHNAME', 'lolor_cleanup_dependencies'
 LANGUAGE C STRICT VOLATILE;
 
+/*
+ * lolor.migrate()
+ *
+ * Incrementally migrate native large objects into lolor storage.
+ *
+ * Parameters:
+ *   n                        - max number of large objects to migrate (NULL = all)
+ *   skip_locked              - if true, skip objects locked by other sessions
+ *   strict_from_end_to_start - if true, select objects by reverse physical block scan
+ *   run_vacuum               - if true, vacuum relations after migration
+ */
+CREATE FUNCTION lolor.migrate(
+    n integer DEFAULT NULL,
+    skip_locked boolean DEFAULT true,
+    strict_from_end_to_start boolean DEFAULT false,
+    run_vacuum boolean DEFAULT false
+)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'lolor_migrate'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION lolor.lolor_migrate(
+    n integer DEFAULT NULL,
+    skip_locked boolean DEFAULT true,
+    strict_from_end_to_start boolean DEFAULT false,
+    run_vacuum boolean DEFAULT false
+)
+RETURNS bigint
+AS 'MODULE_PATHNAME', 'lolor_migrate'
+LANGUAGE C VOLATILE;
+
+
+

--- a/lolor--1.2.2--1.3.0.sql
+++ b/lolor--1.2.2--1.3.0.sql
@@ -373,6 +373,9 @@ RETURNS integer
 AS 'MODULE_PATHNAME', 'lolor_cleanup_dependencies'
 LANGUAGE C STRICT VOLATILE;
 
+REVOKE EXECUTE ON FUNCTION lolor.cleanup_dependencies() FROM PUBLIC;
+
+
 /*
  * lolor.migrate()
  *

--- a/lolor--1.2.2--1.3.0.sql
+++ b/lolor--1.2.2--1.3.0.sql
@@ -377,35 +377,74 @@ REVOKE EXECUTE ON FUNCTION lolor.cleanup_dependencies() FROM PUBLIC;
 
 
 /*
- * lolor.migrate()
+ * lolor.vacuum_native_storage()
  *
- * Incrementally migrate native large objects into lolor storage.
+ * Vacuum native large object catalogs (pg_largeobject and pg_largeobject_metadata)
+ * to reclaim storage and truncate empty pages.
+ */
+CREATE FUNCTION lolor.vacuum_native_storage()
+RETURNS void
+AS 'MODULE_PATHNAME', 'lolor_vacuum_native_storage'
+LANGUAGE C VOLATILE;
+
+REVOKE EXECUTE ON FUNCTION lolor.vacuum_native_storage() FROM PUBLIC;
+
+/*
+ * lolor.lolor_migrate()
+ *
+ * Core C implementation for batch migration of native large objects into lolor storage.
  *
  * Parameters:
  *   n                        - max number of large objects to migrate (NULL = all)
  *   skip_locked              - if true, skip objects locked by other sessions
  *   strict_from_end_to_start - if true, select objects by reverse physical block scan
- *   run_vacuum               - if true, vacuum relations after migration
  */
-CREATE FUNCTION lolor.migrate(
+CREATE FUNCTION lolor.lolor_migrate(
     n integer DEFAULT NULL,
     skip_locked boolean DEFAULT true,
-    strict_from_end_to_start boolean DEFAULT false,
-    run_vacuum boolean DEFAULT false
+    strict_from_end_to_start boolean DEFAULT false
 )
 RETURNS bigint
 AS 'MODULE_PATHNAME', 'lolor_migrate'
 LANGUAGE C VOLATILE;
 
-CREATE FUNCTION lolor.lolor_migrate(
+REVOKE EXECUTE ON FUNCTION lolor.lolor_migrate(integer, boolean, boolean) FROM PUBLIC;
+
+/*
+ * lolor.migrate()
+ *
+ * Procedure to incrementally migrate native large objects into lolor storage.
+ *
+ * When run_vacuum is true and objects were migrated, commits the migration
+ * transaction and runs vacuum in a separate transaction so that the deleted
+ * tuples can be reclaimed and space truncated back to the filesystem.
+ *
+ * Parameters:
+ *   n                        - max number of large objects to migrate (NULL = all)
+ *   skip_locked              - if true, skip objects locked by other sessions
+ *   strict_from_end_to_start - if true, select objects by reverse physical block scan
+ *   run_vacuum               - if true, commit and vacuum relations in a separate transaction
+ *   migrated                 - INOUT: number of large objects migrated
+ */
+CREATE PROCEDURE lolor.migrate(
     n integer DEFAULT NULL,
     skip_locked boolean DEFAULT true,
     strict_from_end_to_start boolean DEFAULT false,
-    run_vacuum boolean DEFAULT false
+    run_vacuum boolean DEFAULT false,
+    INOUT migrated bigint DEFAULT 0
 )
-RETURNS bigint
-AS 'MODULE_PATHNAME', 'lolor_migrate'
-LANGUAGE C VOLATILE;
+LANGUAGE plpgsql AS $$
+BEGIN
+    migrated := lolor.lolor_migrate(n, skip_locked, strict_from_end_to_start);
+    IF run_vacuum AND migrated > 0 THEN
+        COMMIT;
+        PERFORM lolor.vacuum_native_storage();
+    END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON PROCEDURE lolor.migrate(integer, boolean, boolean, boolean, bigint) FROM PUBLIC;
+
 
 
 

--- a/lolor--1.2.2--1.3.0.sql
+++ b/lolor--1.2.2--1.3.0.sql
@@ -184,6 +184,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
+REVOKE EXECUTE ON FUNCTION lolor.migrate_from_native() FROM PUBLIC;
+
 /*
  * lolor.migrate_to_native()
  *
@@ -361,6 +363,8 @@ BEGIN
   RETURN lo_count;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
+
+REVOKE EXECUTE ON FUNCTION lolor.migrate_to_native() FROM PUBLIC;
 
 /*
  * lolor.cleanup_dependencies()

--- a/lolor--1.2.2--1.3.0.sql
+++ b/lolor--1.2.2--1.3.0.sql
@@ -361,3 +361,15 @@ BEGIN
   RETURN lo_count;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
+
+/*
+ * lolor.cleanup_dependencies()
+ *
+ * Remove shared dependencies on lolor.pg_largeobject_metadata for roles
+ * that no longer own or have privileges on any lolor large objects.
+ */
+CREATE FUNCTION lolor.cleanup_dependencies()
+RETURNS integer
+AS 'MODULE_PATHNAME', 'lolor_cleanup_dependencies'
+LANGUAGE C STRICT VOLATILE;
+

--- a/sql/lolor.sql
+++ b/sql/lolor.sql
@@ -456,3 +456,85 @@ SELECT lo_unlink(4001);
 SELECT lo_unlink(4002);
 DROP EXTENSION lolor;
 
+--
+-- lolor.migrate(): incremental batch migration
+--
+CREATE EXTENSION lolor;
+
+-- Ensure any leftover native large objects are migrated first
+SELECT lolor.migrate() >= 0 AS clean_start;
+
+-- 1. Create 5 native large objects
+SELECT lolor.disable();
+SELECT lo_from_bytea(5001, 'Batch migration 1');
+SELECT lo_from_bytea(5002, 'Batch migration 2');
+SELECT lo_from_bytea(5003, 'Batch migration 3');
+SELECT lo_from_bytea(5004, 'Batch migration 4');
+SELECT lo_from_bytea(5005, 'Batch migration 5');
+SELECT lolor.enable();
+
+-- Check initial distribution
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+
+-- Migrate batch of 2
+SELECT lolor.migrate(2);
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+
+-- Migrate all remaining
+SELECT lolor.migrate();
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
+
+-- Calling again returns 0
+SELECT lolor.migrate();
+
+-- 2. strict_from_end_to_start: reverse physical scan
+SELECT lolor.disable();
+SELECT lo_from_bytea(5011, 'End to start 1');
+SELECT lo_from_bytea(5012, 'End to start 2');
+SELECT lo_from_bytea(5013, 'End to start 3');
+SELECT lolor.enable();
+
+-- Reverse scan should pick 5013 first (written last at physical end)
+SELECT lolor.migrate(1, strict_from_end_to_start => true);
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5013;
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5013;
+
+-- Migrate remaining objects with reverse scan
+SELECT lolor.migrate(strict_from_end_to_start => true);
+SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
+SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
+
+-- 3. run_vacuum and procedure call
+SELECT lolor.disable();
+SELECT lo_from_bytea(5021, 'Vacuum test 1');
+SELECT lo_from_bytea(5022, 'Vacuum test 2');
+SELECT lolor.enable();
+
+-- Function with run_vacuum => true
+SELECT lolor.migrate(1, run_vacuum => true);
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5021;
+
+SELECT lolor.migrate(1, run_vacuum => true);
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5022;
+
+-- 4. Alias test: lolor.lolor_migrate
+SELECT lolor.lolor_migrate(0);
+
+
+-- Cleanup
+SELECT lo_unlink(5001);
+SELECT lo_unlink(5002);
+SELECT lo_unlink(5003);
+SELECT lo_unlink(5004);
+SELECT lo_unlink(5005);
+SELECT lo_unlink(5011);
+SELECT lo_unlink(5012);
+SELECT lo_unlink(5013);
+SELECT lo_unlink(5021);
+SELECT lo_unlink(5022);
+DROP EXTENSION lolor;
+
+

--- a/sql/lolor.sql
+++ b/sql/lolor.sql
@@ -355,3 +355,104 @@ SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3003;
 SELECT lo_unlink(3001);
 SELECT lo_unlink(3002);
 DROP EXTENSION lolor;
+
+--
+-- ProcessUtility hook: ALTER, COMMENT, GRANT, REVOKE on LARGE OBJECT
+--
+CREATE EXTENSION lolor;
+
+-- Create test roles
+CREATE ROLE lolor_test_user1;
+CREATE ROLE lolor_test_user2;
+
+-- Create large objects (one in lolor, one native)
+SELECT lo_from_bytea(4001, 'Lolor LO for utility tests');
+
+SELECT lolor.disable();
+SELECT lo_from_bytea(4002, 'Native LO for utility tests');
+SELECT lolor.enable();
+
+-- 1. COMMENT ON LARGE OBJECT
+-- Set comment on lolor object
+COMMENT ON LARGE OBJECT 4001 IS 'Test comment on lolor LO';
+SELECT description FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
+
+-- Set comment on native object
+COMMENT ON LARGE OBJECT 4002 IS 'Test comment on native LO';
+SELECT description FROM pg_description WHERE objoid = 4002 AND classoid = 'pg_largeobject'::regclass;
+
+-- Remove comment by setting to NULL
+COMMENT ON LARGE OBJECT 4001 IS NULL;
+SELECT description FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
+
+-- Error on non-existent object
+COMMENT ON LARGE OBJECT 999999 IS 'Should fail';
+
+-- 2. ALTER LARGE OBJECT ... OWNER TO
+-- Alter owner of lolor object
+ALTER LARGE OBJECT 4001 OWNER TO lolor_test_user1;
+SELECT lomowner = (SELECT oid FROM pg_roles WHERE rolname = 'lolor_test_user1') AS is_user1_owner
+  FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+
+-- Alter owner of native object: should migrate on-the-fly to lolor storage
+ALTER LARGE OBJECT 4002 OWNER TO lolor_test_user1;
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 4002;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 4002;
+SELECT lomowner = (SELECT oid FROM pg_roles WHERE rolname = 'lolor_test_user1') AS is_user1_owner
+  FROM lolor.pg_largeobject_metadata WHERE oid = 4002;
+-- Verify comment on 4002 is still preserved after migration
+SELECT description FROM pg_description WHERE objoid = 4002 AND classoid = 'pg_largeobject'::regclass;
+
+-- Error on non-existent object
+ALTER LARGE OBJECT 999999 OWNER TO lolor_test_user1;
+
+-- 3. GRANT and REVOKE on LARGE OBJECT
+-- Grant SELECT and UPDATE to lolor_test_user2
+GRANT SELECT, UPDATE ON LARGE OBJECT 4001 TO lolor_test_user2;
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+
+-- Revoke UPDATE from lolor_test_user2
+REVOKE UPDATE ON LARGE OBJECT 4001 FROM lolor_test_user2;
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+
+-- Grant ALL PRIVILEGES
+GRANT ALL PRIVILEGES ON LARGE OBJECT 4001 TO lolor_test_user2;
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+
+-- Revoke ALL PRIVILEGES
+REVOKE ALL PRIVILEGES ON LARGE OBJECT 4001 FROM lolor_test_user2;
+SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+
+-- Error on non-existent object
+GRANT SELECT ON LARGE OBJECT 999999 TO lolor_test_user2;
+REVOKE SELECT ON LARGE OBJECT 999999 FROM lolor_test_user2;
+
+-- 4. Dependency tracking and lolor.cleanup_dependencies()
+-- Grant privilege to lolor_test_user2 to record dependency
+GRANT SELECT ON LARGE OBJECT 4001 TO lolor_test_user2;
+
+-- Dropping user1 or user2 should fail because they have dependencies
+DROP ROLE lolor_test_user1;
+DROP ROLE lolor_test_user2;
+
+-- Now transfer ownership back to current user and revoke privileges from user2
+ALTER LARGE OBJECT 4001 OWNER TO CURRENT_USER;
+ALTER LARGE OBJECT 4002 OWNER TO CURRENT_USER;
+REVOKE SELECT ON LARGE OBJECT 4001 FROM lolor_test_user2;
+
+-- Attempting to drop role directly still fails before cleanup
+DROP ROLE lolor_test_user1;
+DROP ROLE lolor_test_user2;
+
+-- Run lolor.cleanup_dependencies()
+SELECT lolor.cleanup_dependencies() >= 2 AS cleaned_deps;
+
+-- Now dropping the roles should succeed!
+DROP ROLE lolor_test_user1;
+DROP ROLE lolor_test_user2;
+
+-- Cleanup
+SELECT lo_unlink(4001);
+SELECT lo_unlink(4002);
+DROP EXTENSION lolor;
+

--- a/sql/lolor.sql
+++ b/sql/lolor.sql
@@ -51,6 +51,7 @@ SELECT lo_open(:loid, 262144) AS fd \gset
 SELECT convert_from(loread(:fd, 1024), 'UTF8');
 SELECT lo_close(:fd);
 END;
+SELECT lo_unlink(:loid);
 
 --
 -- lo_tell: verify cursor position before and after a write.
@@ -72,6 +73,7 @@ SELECT lo_open(:loid, 262144) AS fd \gset
 SELECT convert_from(loread(:fd, 1024), 'UTF8');
 SELECT lo_close(:fd);
 END;
+SELECT lo_unlink(:loid);
 
 --
 -- lo_truncate: truncate to 10 bytes, verify only the prefix survives.
@@ -89,6 +91,7 @@ SELECT lo_open(:loid, 262144) AS fd \gset
 SELECT convert_from(loread(:fd, 1024), 'UTF8');
 SELECT lo_close(:fd);
 END;
+SELECT lo_unlink(:loid);
 
 DROP EXTENSION lolor;
 
@@ -126,10 +129,15 @@ SELECT lo_from_bytea(2, 'Example large object stored in built-in LO storage');
 
 -- We should see the object
 SELECT lolor.enable();
-SELECT lo_open(2, 262144); -- 'not found' ERROR
+BEGIN;
+SELECT lo_open(2, 262144) AS fd \gset
+SELECT convert_from(loread(:fd, 1024), 'UTF8'); -- OK, see the native object
+SELECT lo_close(:fd);
+END;
 BEGIN;
 SELECT lo_open(1, 262144) AS fd \gset
 SELECT convert_from(loread(:fd, 1024), 'UTF8'); -- OK, see the object
+SELECT lo_close(:fd);
 END;
 
 -- To be sure that the behaviour is repeatable
@@ -269,7 +277,8 @@ CREATE EXTENSION lolor;
 SELECT lo_from_bytea(0, 'Drop conflict test') AS drop_conflict_oid \gset
 -- Create a native LO with the same OID to force conflict at DROP time
 SELECT lolor.disable();
-SELECT lo_create(:'drop_conflict_oid');
+SELECT lo_create(:'drop_conflict_oid') AS created_drop_oid \gset
+SELECT :'created_drop_oid' = :'drop_conflict_oid' AS oid_matches;
 SELECT lolor.enable();
 -- DROP EXTENSION should ERROR to prevent data loss
 DROP EXTENSION lolor;
@@ -282,4 +291,67 @@ SELECT lolor.disable();
 SELECT lo_unlink(:'drop_conflict_oid'::oid);
 SELECT lolor.enable();
 -- Now DROP should succeed
+DROP EXTENSION lolor;
+
+--
+-- Zero-downtime migration: transparent reading and on-the-fly migration
+--
+CREATE EXTENSION lolor;
+
+-- 1. Create a native large object while lolor is disabled
+SELECT lolor.disable();
+SELECT lo_from_bytea(3001, 'Native LO data for zero-downtime reading test');
+SELECT lolor.enable();
+
+-- 2. Verify reading via lo_get and lo_get_fragment works transparently with lolor enabled
+SELECT convert_from(lo_get(3001), 'UTF8');
+SELECT convert_from(lo_get(3001, 7, 7), 'UTF8');
+
+-- 3. Verify reading via lo_open, lo_lseek, lo_tell, loread, lo_close
+BEGIN;
+SELECT lo_open(3001, 262144) AS fd \gset
+SELECT lo_tell(:fd);
+SELECT lo_lseek(:fd, 7, 0);
+SELECT lo_tell(:fd);
+SELECT convert_from(loread(:fd, 7), 'UTF8');
+SELECT lo_close(:fd);
+END;
+
+-- 4. Verify object is still in native storage (reads do not migrate)
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3001;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3001;
+
+-- 5. On-the-fly migration on write (lo_put)
+SELECT lo_put(3001, 0, 'MODIFIED');
+-- Now object 3001 must be in lolor storage and gone from native storage!
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3001;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3001;
+SELECT convert_from(lo_get(3001), 'UTF8');
+
+-- 6. On-the-fly migration on write via lo_open(INV_WRITE) + lowrite
+SELECT lolor.disable();
+SELECT lo_from_bytea(3002, 'Native LO for write migration test');
+SELECT lolor.enable();
+BEGIN;
+SELECT lo_open(3002, x'60000'::int) AS fd \gset
+SELECT lowrite(:fd, 'MIGRATED');
+SELECT lo_close(:fd);
+END;
+-- Must be in lolor storage and gone from native storage
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3002;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3002;
+SELECT convert_from(lo_get(3002), 'UTF8');
+
+-- 7. Transparent lo_unlink of native object
+SELECT lolor.disable();
+SELECT lo_from_bytea(3003, 'Native LO to be unlinked');
+SELECT lolor.enable();
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3003;
+SELECT lo_unlink(3003);
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 3003;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 3003;
+
+-- Cleanup migrated objects
+SELECT lo_unlink(3001);
+SELECT lo_unlink(3002);
 DROP EXTENSION lolor;

--- a/sql/lolor.sql
+++ b/sql/lolor.sql
@@ -470,7 +470,7 @@ DROP EXTENSION lolor;
 CREATE EXTENSION lolor;
 
 -- Ensure any leftover native large objects are migrated first
-SELECT lolor.migrate() >= 0 AS clean_start;
+SELECT lolor.lolor_migrate() >= 0 AS clean_start;
 
 -- 1. Create 5 native large objects
 SELECT lolor.disable();
@@ -486,17 +486,17 @@ SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid 
 SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
 
 -- Migrate batch of 2
-SELECT lolor.migrate(2);
+CALL lolor.migrate(2);
 SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
 SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
 
 -- Migrate all remaining
-SELECT lolor.migrate();
+CALL lolor.migrate();
 SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
 SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5001 AND 5005;
 
 -- Calling again returns 0
-SELECT lolor.migrate();
+CALL lolor.migrate();
 
 -- 2. strict_from_end_to_start: reverse physical scan
 SELECT lolor.disable();
@@ -506,12 +506,12 @@ SELECT lo_from_bytea(5013, 'End to start 3');
 SELECT lolor.enable();
 
 -- Reverse scan should pick 5013 first (written last at physical end)
-SELECT lolor.migrate(1, strict_from_end_to_start => true);
+CALL lolor.migrate(1, strict_from_end_to_start => true);
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5013;
 SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5013;
 
 -- Migrate remaining objects with reverse scan
-SELECT lolor.migrate(strict_from_end_to_start => true);
+CALL lolor.migrate(strict_from_end_to_start => true);
 SELECT count(*) AS native_cnt FROM pg_catalog.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
 SELECT count(*) AS lolor_cnt FROM lolor.pg_largeobject_metadata WHERE oid BETWEEN 5011 AND 5013;
 
@@ -521,24 +521,27 @@ SELECT lo_from_bytea(5021, 'Vacuum test 1');
 SELECT lo_from_bytea(5022, 'Vacuum test 2');
 SELECT lolor.enable();
 
--- Function with run_vacuum => true
-SELECT lolor.migrate(1, run_vacuum => true);
+-- Procedure with run_vacuum => true
+CALL lolor.migrate(1, run_vacuum => true);
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5021;
 
-SELECT lolor.migrate(1, run_vacuum => true);
+CALL lolor.migrate(1, run_vacuum => true);
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5022;
 
--- 4. Alias test: lolor.lolor_migrate
+-- Dedicated vacuum helper test
+SELECT lolor.vacuum_native_storage();
+
+-- 4. Core function test: lolor.lolor_migrate
 SELECT lolor.lolor_migrate(0);
 
 -- 5. Negative batch size validation
-SELECT lolor.migrate(-1);
+CALL lolor.migrate(-1);
 
 -- 6. Empty (0-page) large object migrated by reverse mode
 SELECT lolor.disable();
 SELECT lo_create(5030);
 SELECT lolor.enable();
-SELECT lolor.migrate(strict_from_end_to_start => true);
+CALL lolor.migrate(strict_from_end_to_start => true);
 SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5030;
 SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5030;
 SELECT lo_unlink(5030);

--- a/sql/lolor.sql
+++ b/sql/lolor.sql
@@ -417,11 +417,11 @@ SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oi
 
 -- Grant ALL PRIVILEGES
 GRANT ALL PRIVILEGES ON LARGE OBJECT 4001 TO lolor_test_user2;
-SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+SELECT lomacl::text LIKE '%lolor_test_user2=rw/%' AS has_all_privs FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
 
 -- Revoke ALL PRIVILEGES
 REVOKE ALL PRIVILEGES ON LARGE OBJECT 4001 FROM lolor_test_user2;
-SELECT lomacl IS NOT NULL AS has_acl FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
+SELECT lomacl::text NOT LIKE '%lolor_test_user2%' AS revoked_all FROM lolor.pg_largeobject_metadata WHERE oid = 4001;
 
 -- Error on non-existent object
 GRANT SELECT ON LARGE OBJECT 999999 TO lolor_test_user2;
@@ -434,6 +434,11 @@ GRANT SELECT ON LARGE OBJECT 4001 TO lolor_test_user2;
 -- Dropping user1 or user2 should fail because they have dependencies
 DROP ROLE lolor_test_user1;
 DROP ROLE lolor_test_user2;
+
+-- Test security: non-superuser should be denied from cleanup_dependencies
+SET ROLE lolor_test_user1;
+SELECT lolor.cleanup_dependencies();
+RESET ROLE;
 
 -- Now transfer ownership back to current user and revoke privileges from user2
 ALTER LARGE OBJECT 4001 OWNER TO CURRENT_USER;
@@ -451,8 +456,11 @@ SELECT lolor.cleanup_dependencies() >= 2 AS cleaned_deps;
 DROP ROLE lolor_test_user1;
 DROP ROLE lolor_test_user2;
 
--- Cleanup
+-- Verify DeleteComments removes comment on lo_unlink
+COMMENT ON LARGE OBJECT 4001 IS 'Comment before unlink';
+SELECT count(*) FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
 SELECT lo_unlink(4001);
+SELECT count(*) FROM pg_description WHERE objoid = 4001 AND classoid = 'pg_largeobject'::regclass;
 SELECT lo_unlink(4002);
 DROP EXTENSION lolor;
 
@@ -522,6 +530,28 @@ SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5022;
 
 -- 4. Alias test: lolor.lolor_migrate
 SELECT lolor.lolor_migrate(0);
+
+-- 5. Negative batch size validation
+SELECT lolor.migrate(-1);
+
+-- 6. Empty (0-page) large object migrated by reverse mode
+SELECT lolor.disable();
+SELECT lo_create(5030);
+SELECT lolor.enable();
+SELECT lolor.migrate(strict_from_end_to_start => true);
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5030;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5030;
+SELECT lo_unlink(5030);
+
+-- 7. Disabled state passthrough for utility commands
+SELECT lolor.disable();
+SELECT lo_create(5031);
+ALTER LARGE OBJECT 5031 OWNER TO CURRENT_ROLE;
+SELECT count(*) FROM pg_catalog.pg_largeobject_metadata WHERE oid = 5031;
+SELECT count(*) FROM lolor.pg_largeobject_metadata WHERE oid = 5031;
+SELECT lo_unlink(5031);
+SELECT lolor.enable();
+
 
 
 -- Cleanup

--- a/src/lolor.c
+++ b/src/lolor.c
@@ -36,6 +36,7 @@ PG_MODULE_MAGIC;
 int32 lolor_node_id = 0;
 
 void	_PG_init(void);
+void	_PG_fini(void);
 
 /* keep Oids of the large object catalog. */
 static Oid	LOLOR_LargeObjectRelationId = InvalidOid;
@@ -170,6 +171,15 @@ _PG_init(void)
 	 * So, it is necessary to invalidate cache of Oids.
 	 */
 	CacheRegisterRelcacheCallback(relcache_invalidate_callback, (Datum) 0);
+
+	/* Initialize ProcessUtility hook */
+	lolor_utility_init();
+}
+
+void
+_PG_fini(void)
+{
+	lolor_utility_fini();
 }
 
 /*

--- a/src/lolor.h
+++ b/src/lolor.h
@@ -110,4 +110,8 @@ extern void lolor_utility_fini(void);
 extern void lolor_record_role_dependency(Oid roleid);
 extern Datum lolor_cleanup_dependencies(PG_FUNCTION_ARGS);
 
+/* oldloutils.c */
+extern Datum lolor_migrate(PG_FUNCTION_ARGS);
+
 #endif							/* LOLOR_LARGEOBJECT_H */
+

--- a/src/lolor.h
+++ b/src/lolor.h
@@ -112,6 +112,7 @@ extern Datum lolor_cleanup_dependencies(PG_FUNCTION_ARGS);
 
 /* oldloutils.c */
 extern Datum lolor_migrate(PG_FUNCTION_ARGS);
+extern Datum lolor_vacuum_native_storage(PG_FUNCTION_ARGS);
 
 #endif							/* LOLOR_LARGEOBJECT_H */
 

--- a/src/lolor.h
+++ b/src/lolor.h
@@ -102,5 +102,12 @@ extern Datum lolor_lo_from_bytea(PG_FUNCTION_ARGS);
 extern Datum lolor_lo_get(PG_FUNCTION_ARGS);
 extern Datum lolor_lo_get_fragment(PG_FUNCTION_ARGS);
 extern Datum lolor_lo_put(PG_FUNCTION_ARGS);
+extern bool lolor_object_ownercheck(Oid classid, Oid objectid, Oid roleid);
+
+/* lolor_utility.c */
+extern void lolor_utility_init(void);
+extern void lolor_utility_fini(void);
+extern void lolor_record_role_dependency(Oid roleid);
+extern Datum lolor_cleanup_dependencies(PG_FUNCTION_ARGS);
 
 #endif							/* LOLOR_LARGEOBJECT_H */

--- a/src/lolor.h
+++ b/src/lolor.h
@@ -47,6 +47,22 @@ extern int	lolor_inv_read(LargeObjectDesc *obj_desc, char *buf, int nbytes);
 extern int	lolor_inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes);
 extern void lolor_inv_truncate(LargeObjectDesc *obj_desc, int64 len);
 
+/* flag for LargeObjectDesc: object is stored in native pg_catalog */
+#define IFS_NATIVE		(1 << 2)
+
+/* oldloutils.c */
+extern void oldlo_open_lo_relation(void);
+extern void oldlo_close_lo_relation(bool isCommit);
+extern bool oldlo_exists(Oid loid, Snapshot snapshot);
+extern AclResult oldlo_aclcheck(Oid loid, Oid roleid, AclMode mode, Snapshot snapshot);
+extern bool oldlo_ownercheck(Oid loid, Oid roleid);
+extern int	oldlo_read(LargeObjectDesc *obj_desc, char *buf, int nbytes);
+extern int64 oldlo_seek(LargeObjectDesc *obj_desc, int64 offset, int whence);
+extern int64 oldlo_tell(LargeObjectDesc *obj_desc);
+extern uint64 oldlo_getsize(LargeObjectDesc *obj_desc);
+extern int	oldlo_drop(Oid lobjId);
+extern bool oldlo_migrate_one(Oid lobjId);
+
 /* lolor_fsstubs.c */
 
 #ifndef repalloc0_array

--- a/src/lolor_fsstubs.c
+++ b/src/lolor_fsstubs.c
@@ -356,36 +356,67 @@ lolor_lo_unlink(PG_FUNCTION_ARGS)
 	PreventCommandIfReadOnly("lo_unlink()");
 
 	/*
-	 * Must be owner of the large object.  It would be cleaner to check this
-	 * in lolor_inv_drop(), but we want to throw the error before not after closing
-	 * relevant FDs.
+	 * Check whether the object exists in lolor or in native storage.
 	 */
-	if (!lo_compat_privileges &&
-		!lolor_object_ownercheck(get_LOLOR_LargeObjectMetadataRelationId(),
-								 lobjId, GetUserId()))
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be owner of large object %u", lobjId)));
-
-	/*
-	 * If there are any open LO FDs referencing that ID, close 'em.
-	 */
-	if (fscxt != NULL)
+	if (LOLOR_LargeObjectExists(lobjId))
 	{
-		int			i;
+		if (!lo_compat_privileges &&
+			!lolor_object_ownercheck(get_LOLOR_LargeObjectMetadataRelationId(),
+									 lobjId, GetUserId()))
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("must be owner of large object %u", lobjId)));
 
-		for (i = 0; i < cookies_size; i++)
+		/*
+		 * If there are any open LO FDs referencing that ID, close 'em.
+		 */
+		if (fscxt != NULL)
 		{
-			if (cookies[i] != NULL && cookies[i]->id == lobjId)
-				closeLOfd(i);
-		}
-	}
+			int			i;
 
-	/*
-	 * lolor_inv_drop does not create a need for end-of-transaction cleanup and
-	 * hence we don't need to set lo_cleanup_needed.
-	 */
-	PG_RETURN_INT32(lolor_inv_drop(lobjId));
+			for (i = 0; i < cookies_size; i++)
+			{
+				if (cookies[i] != NULL && cookies[i]->id == lobjId)
+					closeLOfd(i);
+			}
+		}
+
+		/*
+		 * lolor_inv_drop does not create a need for end-of-transaction cleanup and
+		 * hence we don't need to set lo_cleanup_needed.
+		 */
+		PG_RETURN_INT32(lolor_inv_drop(lobjId));
+	}
+	else if (oldlo_exists(lobjId, NULL))
+	{
+		if (!lo_compat_privileges &&
+			!oldlo_ownercheck(lobjId, GetUserId()))
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("must be owner of large object %u", lobjId)));
+
+		/*
+		 * If there are any open LO FDs referencing that ID, close 'em.
+		 */
+		if (fscxt != NULL)
+		{
+			int			i;
+
+			for (i = 0; i < cookies_size; i++)
+			{
+				if (cookies[i] != NULL && cookies[i]->id == lobjId)
+					closeLOfd(i);
+			}
+		}
+
+		PG_RETURN_INT32(oldlo_drop(lobjId));
+	}
+	else
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("large object %u does not exist", lobjId)));
+	}
 }
 
 /*****************************************************************************
@@ -672,6 +703,7 @@ AtEOXact_LOLOR_LargeObject(bool isCommit)
 
 	/* Give inv_api.c a chance to clean up, too */
 	lolor_close_lo_relation(isCommit);
+	oldlo_close_lo_relation(isCommit);
 
 	lo_cleanup_needed = false;
 }

--- a/src/lolor_fsstubs.c
+++ b/src/lolor_fsstubs.c
@@ -94,7 +94,6 @@ PG_FUNCTION_INFO_V1(lolor_lo_put);
 
 static int	lo_read(int fd, char *buf, int len);
 static int	lo_write(int fd, const char *buf, int len);
-static bool lolor_object_ownercheck(Oid classid, Oid objectid, Oid roleid);
 static AclMode lolor_largeobject_aclmask_snapshot(Oid lobj_oid, Oid roleid,
 					AclMode mask, AclMaskHow how, Snapshot snapshot);
 
@@ -950,7 +949,7 @@ lolor_lo_put(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
-static bool
+bool
 lolor_object_ownercheck(Oid classid, Oid objectid, Oid roleid)
 {
 	Oid			ownerId;

--- a/src/lolor_inv_api.c
+++ b/src/lolor_inv_api.c
@@ -44,6 +44,7 @@
 #include "catalog/objectaccess.h"
 #include "catalog/pg_largeobject.h"
 #include "catalog/pg_largeobject_metadata.h"
+#include "commands/comment.h"
 #include "libpq/libpq-fs.h"
 #include "miscadmin.h"
 #include "utils/acl.h"
@@ -254,6 +255,7 @@ lolor_inv_open(Oid lobjId, int flags, MemoryContext mcxt)
 	LargeObjectDesc *retval;
 	Snapshot	snapshot = NULL;
 	int			descflags = 0;
+	bool		is_native = false;
 
 	/*
 	 * Historically, no difference is made between (INV_WRITE) and (INV_WRITE
@@ -279,34 +281,87 @@ lolor_inv_open(Oid lobjId, int flags, MemoryContext mcxt)
 
 	/* Can't use LOLOR_LargeObjectExists here because we need to specify snapshot */
 	if (!myLargeObjectExists(lobjId, snapshot))
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("large object %u does not exist", lobjId)));
-
-	/* Apply permission checks, again specifying snapshot */
-	if ((descflags & IFS_RDLOCK) != 0)
 	{
-		if (!lo_compat_privileges &&
-			lolor_largeobject_aclcheck_snapshot(lobjId,
-											 GetUserId(),
-											 ACL_SELECT,
-											 snapshot) != ACLCHECK_OK)
+		if (oldlo_exists(lobjId, snapshot))
+		{
+			is_native = true;
+		}
+		else
+		{
 			ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-					 errmsg("permission denied for large object %u",
-							lobjId)));
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("large object %u does not exist", lobjId)));
+		}
 	}
-	if ((descflags & IFS_WRLOCK) != 0)
+
+	if (is_native)
 	{
-		if (!lo_compat_privileges &&
-			lolor_largeobject_aclcheck_snapshot(lobjId,
-											 GetUserId(),
-											 ACL_UPDATE,
-											 snapshot) != ACLCHECK_OK)
-			ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-					 errmsg("permission denied for large object %u",
-							lobjId)));
+		/*
+		 * If opened for write, migrate on the fly to lolor storage.
+		 */
+		if ((descflags & IFS_WRLOCK) != 0)
+		{
+			if (!lo_compat_privileges &&
+				oldlo_aclcheck(lobjId, GetUserId(), ACL_UPDATE, snapshot) != ACLCHECK_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied for large object %u", lobjId)));
+
+			if (!oldlo_migrate_one(lobjId))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("large object %u does not exist", lobjId)));
+
+			is_native = false;
+
+			if (!lo_compat_privileges &&
+				lolor_largeobject_aclcheck_snapshot(lobjId,
+													GetUserId(),
+													ACL_UPDATE,
+													snapshot) != ACLCHECK_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied for large object %u", lobjId)));
+		}
+		else
+		{
+			/* Read-only access to native object */
+			if (!lo_compat_privileges &&
+				oldlo_aclcheck(lobjId, GetUserId(), ACL_SELECT, snapshot) != ACLCHECK_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied for large object %u", lobjId)));
+
+			descflags |= IFS_NATIVE;
+		}
+	}
+	else
+	{
+		/* Apply permission checks, again specifying snapshot */
+		if ((descflags & IFS_RDLOCK) != 0)
+		{
+			if (!lo_compat_privileges &&
+				lolor_largeobject_aclcheck_snapshot(lobjId,
+													GetUserId(),
+													ACL_SELECT,
+													snapshot) != ACLCHECK_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied for large object %u",
+								lobjId)));
+		}
+		if ((descflags & IFS_WRLOCK) != 0)
+		{
+			if (!lo_compat_privileges &&
+				lolor_largeobject_aclcheck_snapshot(lobjId,
+													GetUserId(),
+													ACL_UPDATE,
+													snapshot) != ACLCHECK_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied for large object %u",
+								lobjId)));
+		}
 	}
 
 	/* OK to create a descriptor */
@@ -350,12 +405,19 @@ lolor_inv_drop(Oid lobjId)
 	ObjectAddress object;
 
 	/*
-	 * Delete any comments and dependencies on the large object
+	 * Delete any comments and dependencies on the large object.
+	 *
+	 * Note: core PostgreSQL's dependency system only recognizes
+	 * LargeObjectRelationId as the object class for large objects.
 	 */
-	object.classId = get_LOLOR_LargeObjectRelationId();
+	object.classId = LargeObjectRelationId;
 	object.objectId = lobjId;
 	object.objectSubId = 0;
 	performDeletion(&object, DROP_CASCADE, PERFORM_DELETION_SKIP_ORIGINAL);
+
+	deleteSharedDependencyRecordsFor(get_LOLOR_LargeObjectRelationId(), lobjId, 0);
+	DeleteComments(lobjId, get_LOLOR_LargeObjectRelationId(), 0);
+
 	LOLOR_LargeObjectDrop(object.objectId);
 
 	/*
@@ -429,6 +491,9 @@ lolor_inv_seek(LargeObjectDesc *obj_desc, int64 offset, int whence)
 
 	Assert(obj_desc);
 
+	if (obj_desc->flags & IFS_NATIVE)
+		return oldlo_seek(obj_desc, offset, whence);
+
 	/*
 	 * We allow seek/tell if you have either read or write permission, so no
 	 * need for a permission check here.
@@ -476,6 +541,9 @@ lolor_inv_tell(LargeObjectDesc *obj_desc)
 {
 	Assert(obj_desc);
 
+	if (obj_desc->flags & IFS_NATIVE)
+		return oldlo_tell(obj_desc);
+
 	/*
 	 * We allow seek/tell if you have either read or write permission, so no
 	 * need for a permission check here.
@@ -499,6 +567,9 @@ lolor_inv_read(LargeObjectDesc *obj_desc, char *buf, int nbytes)
 
 	Assert(obj_desc);
 	Assert(buf != NULL);
+
+	if (obj_desc->flags & IFS_NATIVE)
+		return oldlo_read(obj_desc, buf, nbytes);
 
 	if ((obj_desc->flags & IFS_RDLOCK) == 0)
 		ereport(ERROR,

--- a/src/lolor_inv_api.c
+++ b/src/lolor_inv_api.c
@@ -413,7 +413,7 @@ lolor_inv_drop(Oid lobjId)
 	performDeletion(&object, DROP_CASCADE, PERFORM_DELETION_SKIP_ORIGINAL);
 
 	deleteSharedDependencyRecordsFor(get_LOLOR_LargeObjectRelationId(), lobjId, 0);
-	DeleteComments(lobjId, get_LOLOR_LargeObjectRelationId(), 0);
+	DeleteComments(lobjId, LargeObjectRelationId, 0);
 
 	LOLOR_LargeObjectDrop(object.objectId);
 

--- a/src/lolor_inv_api.c
+++ b/src/lolor_inv_api.c
@@ -218,15 +218,12 @@ lolor_inv_create(Oid lobjId)
 	lobjId_new = LOLOR_LargeObjectCreate(lobjId);
 
 	/*
-	 * dependency on the owner of largeobject
+	 * Dependency on the owner of largeobject.
 	 *
-	 * Note that LO dependencies are recorded using classId
-	 * LOLOR_LargeObjectRelationId for backwards-compatibility reasons.  Using
-	 * LOLOR_LargeObjectMetadataRelationId instead would simplify matters for the
-	 * backend, but it'd complicate pg_dump and possibly break other clients.
+	 * To avoid catalog bloat in pg_shdepend, we record at most one dependency
+	 * per role on lolor.pg_largeobject_metadata instead of one per large object.
 	 */
-	recordDependencyOnOwner(get_LOLOR_LargeObjectRelationId(),
-							lobjId_new, GetUserId());
+	lolor_record_role_dependency(GetUserId());
 
 	/* Post creation hook for new large object */
 	InvokeObjectPostCreateHook(get_LOLOR_LargeObjectRelationId(), lobjId_new, 0);

--- a/src/lolor_largeobject.c
+++ b/src/lolor_largeobject.c
@@ -258,6 +258,9 @@ LOLOR_GetNewOidWithIndex(Relation relation, Oid indexId, AttrNumber oidcolumn)
 
 		systable_endscan(scan);
 
+		if (!collides && oldlo_exists(newOid, SnapshotAny))
+			collides = true;
+
 		/*
 		 * Log that we iterate more than GETNEWOID_LOG_THRESHOLD but have not
 		 * yet found OID unused in the relation. Then repeat logging with

--- a/src/lolor_utility.c
+++ b/src/lolor_utility.c
@@ -1,0 +1,825 @@
+/*-------------------------------------------------------------------------
+ * lolor_utility.c
+ *	  ProcessUtility_hook implementation for lolor extension.
+ *	  Supports ALTER, COMMENT, GRANT, and REVOKE on large objects.
+ *
+ * Copyright (c) 2022-2026, pgEdge, Inc.
+ * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	contrib/lolor/src/lolor_utility.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/genam.h"
+#include "access/heapam.h"
+#include "access/htup_details.h"
+#include "access/table.h"
+#include "access/tableam.h"
+#include "access/xact.h"
+#include "catalog/catalog.h"
+#include "catalog/dependency.h"
+#include "catalog/indexing.h"
+#include "catalog/namespace.h"
+#include "catalog/objectaccess.h"
+#include "catalog/objectaddress.h"
+#include "catalog/pg_authid.h"
+#include "catalog/pg_class.h"
+#include "catalog/pg_largeobject.h"
+#include "catalog/pg_largeobject_metadata.h"
+#include "catalog/pg_shdepend.h"
+#include "commands/comment.h"
+#include "commands/event_trigger.h"
+#include "miscadmin.h"
+#include "nodes/parsenodes.h"
+#include "tcop/utility.h"
+#include "utils/acl.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+#include "utils/syscache.h"
+
+#include "lolor.h"
+
+static ProcessUtility_hook_type prev_ProcessUtility_hook = NULL;
+
+static void lolor_alter_large_object_owner(AlterOwnerStmt *stmt, QueryCompletion *qc);
+static void lolor_comment_large_object(CommentStmt *stmt, QueryCompletion *qc);
+static void lolor_grant_large_object(GrantStmt *stmt, QueryCompletion *qc);
+static bool lolor_is_installed(void);
+static bool lolor_role_is_referenced(Oid roleid);
+static AclMode lolor_string_to_privilege(const char *privname);
+static AclMode lolor_restrict_and_check_grant(bool is_grant, AclMode avail_goptions,
+											  bool all_privs, AclMode privileges,
+											  Oid objectId, Oid grantorId,
+											  Oid ownerId, Acl *old_acl,
+											  const char *objname);
+static Acl *lolor_merge_acl_with_grant(Acl *old_acl, bool is_grant,
+									   bool grant_option, DropBehavior behavior,
+									   List *grantees, AclMode privileges,
+									   Oid grantorId, Oid ownerId);
+
+static void lolor_ProcessUtility(PlannedStmt *pstmt,
+								 const char *queryString,
+								 bool readOnlyTree,
+								 ProcessUtilityContext context,
+								 ParamListInfo params,
+								 QueryEnvironment *queryEnv,
+								 DestReceiver *dest,
+								 QueryCompletion *qc);
+
+PG_FUNCTION_INFO_V1(lolor_cleanup_dependencies);
+
+/*
+ * Initialize ProcessUtility hook.
+ */
+void
+lolor_utility_init(void)
+{
+	prev_ProcessUtility_hook = ProcessUtility_hook;
+	ProcessUtility_hook = lolor_ProcessUtility;
+}
+
+/*
+ * Teardown ProcessUtility hook.
+ */
+void
+lolor_utility_fini(void)
+{
+	ProcessUtility_hook = prev_ProcessUtility_hook;
+}
+
+/*
+ * Check if the lolor extension is installed in the current database.
+ */
+static bool
+lolor_is_installed(void)
+{
+	Oid			nspoid = get_namespace_oid(EXTENSION_NAME, true);
+
+	if (!OidIsValid(nspoid))
+		return false;
+	if (get_relname_relid(LOLOR_LARGEOBJECT_METADATA, nspoid) == InvalidOid)
+		return false;
+	return true;
+}
+
+/*
+ * Record a shared dependency on a role for lolor.pg_largeobject_metadata.
+ *
+ * To avoid catalog bloat in pg_shdepend, we record at most ONE entry per role
+ * across all large objects owned by or granted to that role.
+ */
+void
+lolor_record_role_dependency(Oid roleid)
+{
+	Relation	sdepRel;
+	ScanKeyData key[4];
+	SysScanDesc scan;
+	HeapTuple	tup;
+	bool		found = false;
+	Oid			metaRelId;
+
+	if (!OidIsValid(roleid) || roleid == ACL_ID_PUBLIC ||
+		IsPinnedObject(AuthIdRelationId, roleid))
+		return;
+
+	if (!lolor_is_installed())
+		return;
+
+	metaRelId = get_LOLOR_LargeObjectMetadataRelationId();
+	if (!OidIsValid(metaRelId))
+		return;
+
+	sdepRel = table_open(SharedDependRelationId, RowExclusiveLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_shdepend_dbid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(MyDatabaseId));
+	ScanKeyInit(&key[1],
+				Anum_pg_shdepend_classid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(RelationRelationId));
+	ScanKeyInit(&key[2],
+				Anum_pg_shdepend_objid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(metaRelId));
+	ScanKeyInit(&key[3],
+				Anum_pg_shdepend_objsubid,
+				BTEqualStrategyNumber, F_INT4EQ,
+				Int32GetDatum(0));
+
+	scan = systable_beginscan(sdepRel, SharedDependDependerIndexId, true,
+							  NULL, 4, key);
+	while ((tup = systable_getnext(scan)) != NULL)
+	{
+		Form_pg_shdepend shForm = (Form_pg_shdepend) GETSTRUCT(tup);
+
+		if (shForm->refclassid == AuthIdRelationId && shForm->refobjid == roleid)
+		{
+			found = true;
+			break;
+		}
+	}
+	systable_endscan(scan);
+
+	if (!found)
+	{
+		ObjectAddress depender,
+					referenced;
+
+		depender.classId = RelationRelationId;
+		depender.objectId = metaRelId;
+		depender.objectSubId = 0;
+
+		referenced.classId = AuthIdRelationId;
+		referenced.objectId = roleid;
+		referenced.objectSubId = 0;
+
+		recordSharedDependencyOn(&depender, &referenced, SHARED_DEPENDENCY_OWNER);
+	}
+
+	table_close(sdepRel, RowExclusiveLock);
+}
+
+/*
+ * Helper to check if a role is still referenced in lolor.pg_largeobject_metadata,
+ * either as an owner (lomowner) or within an ACL (lomacl).
+ */
+static bool
+lolor_role_is_referenced(Oid roleid)
+{
+	Relation	metaRel;
+	TableScanDesc scan;
+	HeapTuple	tup;
+	bool		found = false;
+
+	metaRel = table_open(get_LOLOR_LargeObjectMetadataRelationId(), AccessShareLock);
+	scan = table_beginscan_catalog(metaRel, 0, NULL);
+
+	while ((tup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	{
+		Form_pg_largeobject_metadata meta = (Form_pg_largeobject_metadata) GETSTRUCT(tup);
+		Datum		aclDatum;
+		bool		isNull;
+
+		if (meta->lomowner == roleid)
+		{
+			found = true;
+			break;
+		}
+
+		aclDatum = heap_getattr(tup, Anum_pg_largeobject_metadata_lomacl,
+								RelationGetDescr(metaRel), &isNull);
+		if (!isNull)
+		{
+			Acl		   *acl = DatumGetAclP(aclDatum);
+			int			nmembers;
+			Oid		   *members;
+
+			nmembers = aclmembers(acl, &members);
+			for (int i = 0; i < nmembers; i++)
+			{
+				if (members[i] == roleid)
+				{
+					found = true;
+					break;
+				}
+			}
+			if (members)
+				pfree(members);
+			if (found)
+				break;
+		}
+	}
+
+	table_endscan(scan);
+	table_close(metaRel, AccessShareLock);
+
+	return found;
+}
+
+/*
+ * SQL-callable function: lolor.cleanup_dependencies()
+ *
+ * Removes pg_shdepend records on lolor.pg_largeobject_metadata for roles
+ * that no longer own or have privileges on any lolor large objects.
+ * Returns the number of dependency entries removed.
+ */
+Datum
+lolor_cleanup_dependencies(PG_FUNCTION_ARGS)
+{
+	Relation	sdepRel;
+	ScanKeyData key[4];
+	SysScanDesc scan;
+	HeapTuple	tup;
+	int			deleted_count = 0;
+	Oid			metaRelId;
+	List	   *roles_to_check = NIL;
+	ListCell   *lc;
+
+	if (!lolor_is_installed())
+		PG_RETURN_INT32(0);
+
+	metaRelId = get_LOLOR_LargeObjectMetadataRelationId();
+	sdepRel = table_open(SharedDependRelationId, RowExclusiveLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_shdepend_dbid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(MyDatabaseId));
+	ScanKeyInit(&key[1],
+				Anum_pg_shdepend_classid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(RelationRelationId));
+	ScanKeyInit(&key[2],
+				Anum_pg_shdepend_objid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(metaRelId));
+	ScanKeyInit(&key[3],
+				Anum_pg_shdepend_objsubid,
+				BTEqualStrategyNumber, F_INT4EQ,
+				Int32GetDatum(0));
+
+	scan = systable_beginscan(sdepRel, SharedDependDependerIndexId, true,
+							  NULL, 4, key);
+	while ((tup = systable_getnext(scan)) != NULL)
+	{
+		Form_pg_shdepend shForm = (Form_pg_shdepend) GETSTRUCT(tup);
+
+		if (shForm->refclassid == AuthIdRelationId)
+			roles_to_check = lappend_oid(roles_to_check, shForm->refobjid);
+	}
+	systable_endscan(scan);
+
+	foreach(lc, roles_to_check)
+	{
+		Oid			roleid = lfirst_oid(lc);
+
+		if (!lolor_role_is_referenced(roleid))
+		{
+			SysScanDesc dropscan;
+			HeapTuple	droptup;
+
+			dropscan = systable_beginscan(sdepRel, SharedDependDependerIndexId, true,
+										  NULL, 4, key);
+			while ((droptup = systable_getnext(dropscan)) != NULL)
+			{
+				Form_pg_shdepend shForm = (Form_pg_shdepend) GETSTRUCT(droptup);
+
+				if (shForm->refclassid == AuthIdRelationId &&
+					shForm->refobjid == roleid)
+				{
+					CatalogTupleDelete(sdepRel, &droptup->t_self);
+					deleted_count++;
+				}
+			}
+			systable_endscan(dropscan);
+		}
+	}
+
+	table_close(sdepRel, RowExclusiveLock);
+
+	PG_RETURN_INT32(deleted_count);
+}
+
+/*
+ * Handle ALTER LARGE OBJECT <oid> OWNER TO <new_owner>
+ */
+static void
+lolor_alter_large_object_owner(AlterOwnerStmt *stmt, QueryCompletion *qc)
+{
+	Oid			loid = oidparse(stmt->object);
+	Oid			new_ownerId = get_rolespec_oid(stmt->newowner, false);
+	Relation	rel;
+	ScanKeyData skey[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	Form_pg_largeobject_metadata form;
+	Oid			old_ownerId;
+	Datum		values[Natts_pg_largeobject_metadata];
+	bool		nulls[Natts_pg_largeobject_metadata];
+	bool		replaces[Natts_pg_largeobject_metadata];
+	Datum		aclDatum;
+	bool		isNull;
+	HeapTuple	newtup;
+	ObjectAddress address;
+
+	if (!LOLOR_LargeObjectExists(loid))
+	{
+		if (oldlo_exists(loid, NULL))
+		{
+			if (!oldlo_migrate_one(loid))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("large object %u does not exist", loid)));
+		}
+		else
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("large object %u does not exist", loid)));
+		}
+	}
+
+	rel = table_open(get_LOLOR_LargeObjectMetadataRelationId(), RowExclusiveLock);
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_largeobject_metadata_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(loid));
+
+	scan = systable_beginscan(rel, get_LOLOR_LargeObjectMetadataOidIndexId(), true,
+							  NULL, 1, skey);
+	tuple = systable_getnext(scan);
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("large object %u does not exist", loid)));
+
+	form = (Form_pg_largeobject_metadata) GETSTRUCT(tuple);
+	old_ownerId = form->lomowner;
+
+	if (!superuser())
+	{
+		if (!has_privs_of_role(GetUserId(), old_ownerId))
+			aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_LARGEOBJECT, psprintf("%u", loid));
+		check_can_set_role(GetUserId(), new_ownerId);
+	}
+
+	if (old_ownerId != new_ownerId)
+	{
+		memset(values, 0, sizeof(values));
+		memset(nulls, false, sizeof(nulls));
+		memset(replaces, false, sizeof(replaces));
+
+		values[Anum_pg_largeobject_metadata_lomowner - 1] = ObjectIdGetDatum(new_ownerId);
+		replaces[Anum_pg_largeobject_metadata_lomowner - 1] = true;
+
+		aclDatum = heap_getattr(tuple, Anum_pg_largeobject_metadata_lomacl,
+								RelationGetDescr(rel), &isNull);
+		if (!isNull)
+		{
+			Acl		   *old_acl = DatumGetAclP(aclDatum);
+			Acl		   *new_acl = aclnewowner(old_acl, old_ownerId, new_ownerId);
+
+			values[Anum_pg_largeobject_metadata_lomacl - 1] = PointerGetDatum(new_acl);
+			replaces[Anum_pg_largeobject_metadata_lomacl - 1] = true;
+		}
+
+		newtup = heap_modify_tuple(tuple, RelationGetDescr(rel), values, nulls, replaces);
+		CatalogTupleUpdate(rel, &newtup->t_self, newtup);
+
+		lolor_record_role_dependency(new_ownerId);
+	}
+
+	systable_endscan(scan);
+	table_close(rel, RowExclusiveLock);
+
+	InvokeObjectPostAlterHook(LargeObjectRelationId, loid, 0);
+	CommandCounterIncrement();
+
+	ObjectAddressSet(address, LargeObjectRelationId, loid);
+	EventTriggerCollectSimpleCommand(address, InvalidObjectAddress, (Node *) stmt);
+
+	if (qc)
+		SetQueryCompletion(qc, CMDTAG_ALTER_LARGE_OBJECT, 0);
+}
+
+/*
+ * Handle COMMENT ON LARGE OBJECT <oid> IS <comment>
+ */
+static void
+lolor_comment_large_object(CommentStmt *stmt, QueryCompletion *qc)
+{
+	Oid			loid = oidparse(stmt->object);
+	bool		in_lolor = LOLOR_LargeObjectExists(loid);
+	bool		in_native = !in_lolor && oldlo_exists(loid, NULL);
+	ObjectAddress address;
+
+	if (!in_lolor && !in_native)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("large object %u does not exist", loid)));
+
+	if (!superuser())
+	{
+		if (in_lolor)
+		{
+			if (!lolor_object_ownercheck(get_LOLOR_LargeObjectMetadataRelationId(),
+										 loid, GetUserId()))
+				aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_LARGEOBJECT, psprintf("%u", loid));
+		}
+		else
+		{
+			if (!oldlo_ownercheck(loid, GetUserId()))
+				aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_LARGEOBJECT, psprintf("%u", loid));
+		}
+	}
+
+	CreateComments(loid, LargeObjectRelationId, 0, stmt->comment);
+
+	ObjectAddressSet(address, LargeObjectRelationId, loid);
+	EventTriggerCollectSimpleCommand(address, InvalidObjectAddress, (Node *) stmt);
+
+	if (qc)
+		SetQueryCompletion(qc, CMDTAG_COMMENT, 0);
+}
+
+/*
+ * Restrict privileges to what the grantor can actually grant/revoke,
+ * and emit standard PostgreSQL warnings.
+ */
+static AclMode
+lolor_restrict_and_check_grant(bool is_grant, AclMode avail_goptions, bool all_privs,
+							   AclMode privileges, Oid objectId, Oid grantorId,
+							   Oid ownerId, Acl *old_acl, const char *objname)
+{
+	AclMode		this_privileges;
+	AclMode		whole_mask = ACL_ALL_RIGHTS_LARGEOBJECT;
+
+	if (avail_goptions == ACL_NO_RIGHTS)
+	{
+		if (aclmask(old_acl, grantorId, ownerId,
+					whole_mask | ACL_GRANT_OPTION_FOR(whole_mask),
+					ACLMASK_ANY) == ACL_NO_RIGHTS)
+		{
+			aclcheck_error(ACLCHECK_NO_PRIV, OBJECT_LARGEOBJECT, objname);
+		}
+	}
+
+	this_privileges = privileges & ACL_OPTION_TO_PRIVS(avail_goptions);
+	if (is_grant)
+	{
+		if (this_privileges == 0)
+		{
+			ereport(WARNING,
+					(errcode(ERRCODE_WARNING_PRIVILEGE_NOT_GRANTED),
+					 errmsg("no privileges were granted for \"%s\"", objname)));
+		}
+		else if (!all_privs && this_privileges != privileges)
+		{
+			ereport(WARNING,
+					(errcode(ERRCODE_WARNING_PRIVILEGE_NOT_GRANTED),
+					 errmsg("not all privileges were granted for \"%s\"", objname)));
+		}
+	}
+	else
+	{
+		if (this_privileges == 0)
+		{
+			ereport(WARNING,
+					(errcode(ERRCODE_WARNING_PRIVILEGE_NOT_REVOKED),
+					 errmsg("no privileges could be revoked for \"%s\"", objname)));
+		}
+		else if (!all_privs && this_privileges != privileges)
+		{
+			ereport(WARNING,
+					(errcode(ERRCODE_WARNING_PRIVILEGE_NOT_REVOKED),
+					 errmsg("not all privileges could be revoked for \"%s\"", objname)));
+		}
+	}
+
+	return this_privileges;
+}
+
+/*
+ * Merge privileges with existing ACL.
+ */
+static Acl *
+lolor_merge_acl_with_grant(Acl *old_acl, bool is_grant,
+						   bool grant_option, DropBehavior behavior,
+						   List *grantees, AclMode privileges,
+						   Oid grantorId, Oid ownerId)
+{
+	unsigned	modechg = is_grant ? ACL_MODECHG_ADD : ACL_MODECHG_DEL;
+	ListCell   *j;
+	Acl		   *new_acl = old_acl;
+
+	foreach(j, grantees)
+	{
+		AclItem		aclitem;
+		Acl		   *newer_acl;
+
+		aclitem.ai_grantee = lfirst_oid(j);
+
+		if (is_grant && grant_option && aclitem.ai_grantee == ACL_ID_PUBLIC)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_GRANT_OPERATION),
+					 errmsg("grant options can only be granted to roles")));
+
+		aclitem.ai_grantor = grantorId;
+
+		ACLITEM_SET_PRIVS_GOPTIONS(aclitem,
+								   (is_grant || !grant_option) ? privileges : ACL_NO_RIGHTS,
+								   (!is_grant || grant_option) ? privileges : ACL_NO_RIGHTS);
+
+		newer_acl = aclupdate(new_acl, &aclitem, modechg, ownerId, behavior);
+
+		pfree(new_acl);
+		new_acl = newer_acl;
+	}
+
+	return new_acl;
+}
+
+static AclMode
+lolor_string_to_privilege(const char *privname)
+{
+	if (strcmp(privname, "select") == 0)
+		return ACL_SELECT;
+	if (strcmp(privname, "update") == 0)
+		return ACL_UPDATE;
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_GRANT_OPERATION),
+			 errmsg("invalid privilege type \"%s\" for large object", privname)));
+	return 0;
+}
+
+/*
+ * Handle GRANT and REVOKE on LARGE OBJECT
+ */
+static void
+lolor_grant_large_object(GrantStmt *stmt, QueryCompletion *qc)
+{
+	ListCell   *cell;
+	List	   *grantee_ids = NIL;
+	bool		all_privs;
+	AclMode		privileges = ACL_NO_RIGHTS;
+	InternalGrant istmt;
+
+	/* Parse grantees */
+	foreach(cell, stmt->grantees)
+	{
+		RoleSpec   *grantee = (RoleSpec *) lfirst(cell);
+		Oid			grantee_uid;
+
+		switch (grantee->roletype)
+		{
+			case ROLESPEC_PUBLIC:
+				grantee_uid = ACL_ID_PUBLIC;
+				break;
+			default:
+				grantee_uid = get_rolespec_oid(grantee, false);
+				break;
+		}
+		grantee_ids = lappend_oid(grantee_ids, grantee_uid);
+	}
+
+	/* Parse privileges */
+	if (stmt->privileges == NIL)
+	{
+		all_privs = true;
+		privileges = ACL_NO_RIGHTS;
+	}
+	else
+	{
+		all_privs = false;
+		foreach(cell, stmt->privileges)
+		{
+			AccessPriv *privnode = (AccessPriv *) lfirst(cell);
+			AclMode		priv;
+
+			if (privnode->cols)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_GRANT_OPERATION),
+						 errmsg("column privileges are only valid for relations")));
+
+			if (privnode->priv_name == NULL)
+				elog(ERROR, "AccessPriv node must specify privilege or columns");
+
+			priv = lolor_string_to_privilege(privnode->priv_name);
+			privileges |= priv;
+		}
+	}
+
+	istmt.is_grant = stmt->is_grant;
+	istmt.objtype = stmt->objtype;
+	istmt.objects = NIL;
+	istmt.all_privs = all_privs;
+	istmt.privileges = privileges;
+	istmt.col_privs = NIL;
+	istmt.grantees = grantee_ids;
+	istmt.grant_option = stmt->grant_option;
+	istmt.grantor = stmt->grantor;
+	istmt.behavior = stmt->behavior;
+
+	/* For each target large object */
+	foreach(cell, stmt->objects)
+	{
+		Oid			loid = oidparse((Node *) lfirst(cell));
+		Relation	rel;
+		ScanKeyData skey[1];
+		SysScanDesc scan;
+		HeapTuple	tuple;
+		Form_pg_largeobject_metadata form;
+		Oid			ownerId;
+		Datum		aclDatum;
+		bool		isNull;
+		Acl		   *old_acl;
+		Oid			grantorId;
+		AclMode		avail_goptions;
+		AclMode		this_privileges;
+		Acl		   *new_acl;
+		Datum		values[Natts_pg_largeobject_metadata];
+		bool		nulls[Natts_pg_largeobject_metadata];
+		bool		replaces[Natts_pg_largeobject_metadata];
+		HeapTuple	newtup;
+		char		objname[NAMEDATALEN];
+
+		if (!LOLOR_LargeObjectExists(loid))
+		{
+			if (oldlo_exists(loid, NULL))
+			{
+				if (!oldlo_migrate_one(loid))
+					ereport(ERROR,
+							(errcode(ERRCODE_UNDEFINED_OBJECT),
+							 errmsg("large object %u does not exist", loid)));
+			}
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("large object %u does not exist", loid)));
+			}
+		}
+
+		istmt.objects = lappend_oid(istmt.objects, loid);
+
+		rel = table_open(get_LOLOR_LargeObjectMetadataRelationId(), RowExclusiveLock);
+
+		ScanKeyInit(&skey[0],
+					Anum_pg_largeobject_metadata_oid,
+					BTEqualStrategyNumber, F_OIDEQ,
+					ObjectIdGetDatum(loid));
+
+		scan = systable_beginscan(rel, get_LOLOR_LargeObjectMetadataOidIndexId(), true,
+								  NULL, 1, skey);
+		tuple = systable_getnext(scan);
+		if (!HeapTupleIsValid(tuple))
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("large object %u does not exist", loid)));
+
+		form = (Form_pg_largeobject_metadata) GETSTRUCT(tuple);
+		ownerId = form->lomowner;
+
+		aclDatum = heap_getattr(tuple, Anum_pg_largeobject_metadata_lomacl,
+								RelationGetDescr(rel), &isNull);
+		if (isNull)
+			old_acl = acldefault(OBJECT_LARGEOBJECT, ownerId);
+		else
+			old_acl = DatumGetAclPCopy(aclDatum);
+
+		select_best_grantor(stmt->grantor, privileges, old_acl, ownerId,
+							&grantorId, &avail_goptions);
+
+		snprintf(objname, sizeof(objname), "large object %u", loid);
+		this_privileges = lolor_restrict_and_check_grant(stmt->is_grant, avail_goptions,
+														 all_privs, privileges,
+														 loid, grantorId,
+														 ownerId, old_acl, objname);
+
+		new_acl = lolor_merge_acl_with_grant(old_acl, stmt->is_grant,
+											 stmt->grant_option, stmt->behavior,
+											 grantee_ids, this_privileges,
+											 grantorId, ownerId);
+
+		memset(values, 0, sizeof(values));
+		memset(nulls, false, sizeof(nulls));
+		memset(replaces, false, sizeof(replaces));
+
+		values[Anum_pg_largeobject_metadata_lomacl - 1] = PointerGetDatum(new_acl);
+		replaces[Anum_pg_largeobject_metadata_lomacl - 1] = true;
+
+		newtup = heap_modify_tuple(tuple, RelationGetDescr(rel), values, nulls, replaces);
+		CatalogTupleUpdate(rel, &newtup->t_self, newtup);
+
+		if (stmt->is_grant)
+		{
+			ListCell   *gc;
+
+			foreach(gc, grantee_ids)
+			{
+				Oid			uid = lfirst_oid(gc);
+
+				lolor_record_role_dependency(uid);
+			}
+		}
+
+		systable_endscan(scan);
+		table_close(rel, RowExclusiveLock);
+
+		CommandCounterIncrement();
+	}
+
+	EventTriggerCollectGrant(&istmt);
+
+	if (qc)
+		SetQueryCompletion(qc, stmt->is_grant ? CMDTAG_GRANT : CMDTAG_REVOKE, 0);
+}
+
+/*
+ * ProcessUtility hook function.
+ */
+static void
+lolor_ProcessUtility(PlannedStmt *pstmt,
+					 const char *queryString,
+					 bool readOnlyTree,
+					 ProcessUtilityContext context,
+					 ParamListInfo params,
+					 QueryEnvironment *queryEnv,
+					 DestReceiver *dest,
+					 QueryCompletion *qc)
+{
+	Node	   *parsetree = pstmt->utilityStmt;
+
+	if (lolor_is_installed())
+	{
+		if (IsA(parsetree, AlterOwnerStmt))
+		{
+			AlterOwnerStmt *stmt = (AlterOwnerStmt *) parsetree;
+
+			if (stmt->objectType == OBJECT_LARGEOBJECT)
+			{
+				lolor_alter_large_object_owner(stmt, qc);
+				return;
+			}
+		}
+		else if (IsA(parsetree, CommentStmt))
+		{
+			CommentStmt *stmt = (CommentStmt *) parsetree;
+
+			if (stmt->objtype == OBJECT_LARGEOBJECT)
+			{
+				lolor_comment_large_object(stmt, qc);
+				return;
+			}
+		}
+		else if (IsA(parsetree, GrantStmt))
+		{
+			GrantStmt  *stmt = (GrantStmt *) parsetree;
+
+			if (stmt->objtype == OBJECT_LARGEOBJECT)
+			{
+				lolor_grant_large_object(stmt, qc);
+				return;
+			}
+		}
+	}
+
+	if (prev_ProcessUtility_hook)
+		(*prev_ProcessUtility_hook) (pstmt, queryString, readOnlyTree,
+									 context, params, queryEnv,
+									 dest, qc);
+	else
+		standard_ProcessUtility(pstmt, queryString, readOnlyTree,
+								context, params, queryEnv,
+								dest, qc);
+}

--- a/src/lolor_utility.c
+++ b/src/lolor_utility.c
@@ -39,6 +39,7 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -108,6 +109,24 @@ lolor_is_installed(void)
 		return false;
 	return true;
 }
+
+/*
+ * Check whether lolor is currently enabled (functions point to lolor).
+ * When lolor.disable() is called, pg_catalog.lo_open is renamed to lolor_lo_open.
+ */
+static bool
+lolor_is_enabled(void)
+{
+	CatCList   *catlist;
+	bool		enabled = true;
+
+	catlist = SearchSysCacheList1(PROCNAMEARGSNSP, CStringGetDatum("lolor_lo_open"));
+	if (catlist->n_members > 0)
+		enabled = false;
+	ReleaseSysCacheList(catlist);
+	return enabled;
+}
+
 
 /*
  * Record a shared dependency on a role for lolor.pg_largeobject_metadata.
@@ -256,6 +275,7 @@ Datum
 lolor_cleanup_dependencies(PG_FUNCTION_ARGS)
 {
 	Relation	sdepRel;
+	Relation	metaRel;
 	ScanKeyData key[4];
 	SysScanDesc scan;
 	HeapTuple	tup;
@@ -264,11 +284,23 @@ lolor_cleanup_dependencies(PG_FUNCTION_ARGS)
 	List	   *roles_to_check = NIL;
 	ListCell   *lc;
 
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to cleanup lolor dependencies")));
+
 	if (!lolor_is_installed())
 		PG_RETURN_INT32(0);
 
 	metaRelId = get_LOLOR_LargeObjectMetadataRelationId();
+
+	/*
+	 * Acquire ShareLock on lolor.pg_largeobject_metadata to serialize
+	 * against concurrent large object creation (which acquires RowExclusiveLock).
+	 */
+	metaRel = table_open(metaRelId, ShareLock);
 	sdepRel = table_open(SharedDependRelationId, RowExclusiveLock);
+
 
 	ScanKeyInit(&key[0],
 				Anum_pg_shdepend_dbid,
@@ -325,8 +357,10 @@ lolor_cleanup_dependencies(PG_FUNCTION_ARGS)
 	}
 
 	table_close(sdepRel, RowExclusiveLock);
+	table_close(metaRel, ShareLock);
 
 	PG_RETURN_INT32(deleted_count);
+
 }
 
 /*
@@ -616,8 +650,9 @@ lolor_grant_large_object(GrantStmt *stmt, QueryCompletion *qc)
 	if (stmt->privileges == NIL)
 	{
 		all_privs = true;
-		privileges = ACL_NO_RIGHTS;
+		privileges = ACL_ALL_RIGHTS_LARGEOBJECT;
 	}
+
 	else
 	{
 		all_privs = false;
@@ -780,7 +815,7 @@ lolor_ProcessUtility(PlannedStmt *pstmt,
 {
 	Node	   *parsetree = pstmt->utilityStmt;
 
-	if (lolor_is_installed())
+	if (lolor_is_installed() && lolor_is_enabled())
 	{
 		if (IsA(parsetree, AlterOwnerStmt))
 		{

--- a/src/lolor_utility.c
+++ b/src/lolor_utility.c
@@ -32,6 +32,7 @@
 #include "catalog/pg_largeobject.h"
 #include "catalog/pg_largeobject_metadata.h"
 #include "catalog/pg_shdepend.h"
+#include "catalog/pg_namespace.h"
 #include "commands/comment.h"
 #include "commands/event_trigger.h"
 #include "miscadmin.h"
@@ -815,35 +816,25 @@ lolor_ProcessUtility(PlannedStmt *pstmt,
 {
 	Node	   *parsetree = pstmt->utilityStmt;
 
-	if (lolor_is_installed() && lolor_is_enabled())
+	if ((IsA(parsetree, AlterOwnerStmt) && ((AlterOwnerStmt *) parsetree)->objectType == OBJECT_LARGEOBJECT) ||
+		(IsA(parsetree, CommentStmt) && ((CommentStmt *) parsetree)->objtype == OBJECT_LARGEOBJECT) ||
+		(IsA(parsetree, GrantStmt) && ((GrantStmt *) parsetree)->objtype == OBJECT_LARGEOBJECT))
 	{
-		if (IsA(parsetree, AlterOwnerStmt))
+		if (lolor_is_installed() && lolor_is_enabled())
 		{
-			AlterOwnerStmt *stmt = (AlterOwnerStmt *) parsetree;
-
-			if (stmt->objectType == OBJECT_LARGEOBJECT)
+			if (IsA(parsetree, AlterOwnerStmt))
 			{
-				lolor_alter_large_object_owner(stmt, qc);
+				lolor_alter_large_object_owner((AlterOwnerStmt *) parsetree, qc);
 				return;
 			}
-		}
-		else if (IsA(parsetree, CommentStmt))
-		{
-			CommentStmt *stmt = (CommentStmt *) parsetree;
-
-			if (stmt->objtype == OBJECT_LARGEOBJECT)
+			else if (IsA(parsetree, CommentStmt))
 			{
-				lolor_comment_large_object(stmt, qc);
+				lolor_comment_large_object((CommentStmt *) parsetree, qc);
 				return;
 			}
-		}
-		else if (IsA(parsetree, GrantStmt))
-		{
-			GrantStmt  *stmt = (GrantStmt *) parsetree;
-
-			if (stmt->objtype == OBJECT_LARGEOBJECT)
+			else if (IsA(parsetree, GrantStmt))
 			{
-				lolor_grant_large_object(stmt, qc);
+				lolor_grant_large_object((GrantStmt *) parsetree, qc);
 				return;
 			}
 		}
@@ -858,3 +849,4 @@ lolor_ProcessUtility(PlannedStmt *pstmt,
 								context, params, queryEnv,
 								dest, qc);
 }
+

--- a/src/oldloutils.c
+++ b/src/oldloutils.c
@@ -417,21 +417,11 @@ oldlo_read(LargeObjectDesc *obj_desc, char *buf, int nbytes)
 int
 oldlo_drop(Oid lobjId)
 {
-	ObjectAddress object;
-
 	oldlo_close_lo_relation(false);
 
-	object.classId = LargeObjectRelationId;
-	object.objectId = lobjId;
-	object.objectSubId = 0;
-	performDeletion(&object, DROP_CASCADE, PERFORM_DELETION_SKIP_ORIGINAL);
-
-	LargeObjectDrop(object.objectId);
-
-	CommandCounterIncrement();
-
-	return 1;
+	return inv_drop(lobjId);
 }
+
 
 /*
  * Migrate a single large object on-the-fly from native storage to lolor storage.
@@ -554,7 +544,10 @@ oldlo_migrate_one(Oid lobjId)
 		bool		dnulls[Natts_pg_largeobject];
 		HeapTuple	new_data_tup;
 
+		CHECK_FOR_INTERRUPTS();
+
 		oldlo_getdatafield(olddata, &datafield, &len, &pfreeit);
+
 
 		memset(dvalues, 0, sizeof(dvalues));
 		memset(dnulls, false, sizeof(dnulls));
@@ -614,14 +607,6 @@ lolor_collect_oids_reverse(int max_count)
 	HASHCTL		ctl;
 	Snapshot	snapshot;
 
-	lo_rel = table_open(LargeObjectRelationId, AccessShareLock);
-	nblocks = RelationGetNumberOfBlocks(lo_rel);
-	if (nblocks == 0)
-	{
-		table_close(lo_rel, AccessShareLock);
-		return NIL;
-	}
-
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize = sizeof(Oid);
 	ctl.entrysize = sizeof(Oid);
@@ -633,13 +618,18 @@ lolor_collect_oids_reverse(int max_count)
 
 	snapshot = GetActiveSnapshot();
 
+	lo_rel = table_open(LargeObjectRelationId, AccessShareLock);
+	nblocks = RelationGetNumberOfBlocks(lo_rel);
+
 	/* Scan blocks backwards from the last block down to 0 */
-	for (blk = nblocks - 1; blk != InvalidBlockNumber; blk--)
+	for (blk = (nblocks > 0 ? nblocks - 1 : InvalidBlockNumber); blk != InvalidBlockNumber; blk--)
 	{
 		Buffer		buf;
 		Page		page;
 		OffsetNumber maxoff;
 		OffsetNumber off;
+
+		CHECK_FOR_INTERRUPTS();
 
 		buf = ReadBuffer(lo_rel, blk);
 		LockBuffer(buf, BUFFER_LOCK_SHARE);
@@ -696,12 +686,46 @@ lolor_collect_oids_reverse(int max_count)
 			break;
 	}
 
+	/*
+	 * Also sweep pg_largeobject_metadata for any empty (0-page) large objects
+	 * that have no rows in pg_largeobject.
+	 */
+	if (max_count <= 0 || list_length(oid_list) < max_count)
+	{
+		Relation	meta_rel;
+		SysScanDesc mscan;
+		HeapTuple	mtup;
+
+		meta_rel = table_open(LargeObjectMetadataRelationId, AccessShareLock);
+		mscan = systable_beginscan(meta_rel, LargeObjectMetadataOidIndexId, true,
+								   NULL, 0, NULL);
+		while (HeapTupleIsValid(mtup = systable_getnext(mscan)))
+		{
+			Form_pg_largeobject_metadata form = (Form_pg_largeobject_metadata) GETSTRUCT(mtup);
+			Oid			loid = form->oid;
+			bool		found;
+
+			CHECK_FOR_INTERRUPTS();
+
+			hash_search(seen_oids, &loid, HASH_ENTER, &found);
+			if (!found)
+			{
+				oid_list = lappend_oid(oid_list, loid);
+				if (max_count > 0 && list_length(oid_list) >= max_count)
+					break;
+			}
+		}
+		systable_endscan(mscan);
+		table_close(meta_rel, AccessShareLock);
+	}
+
 done_scan:
 	hash_destroy(seen_oids);
 	table_close(lo_rel, AccessShareLock);
 
 	return oid_list;
 }
+
 
 /*
  * Helper: collect OIDs in forward catalog order from
@@ -772,7 +796,13 @@ lolor_migrate(PG_FUNCTION_ARGS)
 				 errmsg("lolor extension tables are not accessible")));
 
 	if (PG_NARGS() > 0 && !PG_ARGISNULL(0))
+	{
 		max_count = PG_GETARG_INT32(0);
+		if (max_count < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("lolor.migrate() batch size must not be negative")));
+	}
 	if (PG_NARGS() > 1 && !PG_ARGISNULL(1))
 		skip_locked = PG_GETARG_BOOL(1);
 	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
@@ -783,70 +813,99 @@ lolor_migrate(PG_FUNCTION_ARGS)
 	if (max_count == 0)
 		PG_RETURN_INT64(0);
 
-	/* 1. Collect candidate OIDs */
-	if (strict_from_end_to_start)
-		candidate_oids = lolor_collect_oids_reverse(max_count);
-	else
-		candidate_oids = lolor_collect_oids_forward(max_count);
-
-	/* 2. Lock and migrate each candidate */
-	foreach(lc, candidate_oids)
+	while (true)
 	{
-		Oid			loid = lfirst_oid(lc);
-		Relation	native_meta;
-		ScanKeyData skey[1];
-		SysScanDesc scan;
-		HeapTuple	tuple;
-		ItemPointerData ctid;
-		TM_Result	tm_result;
-		TM_FailureData tmfd;
-		TupleTableSlot *slot;
-		LockWaitPolicy wait_policy = skip_locked ? LockWaitSkip : LockWaitBlock;
+		int			batch_limit;
+		int64		batch_migrated = 0;
 
-		native_meta = table_open(LargeObjectMetadataRelationId, RowExclusiveLock);
+		CHECK_FOR_INTERRUPTS();
 
-		ScanKeyInit(&skey[0],
-					Anum_pg_largeobject_metadata_oid,
-					BTEqualStrategyNumber, F_OIDEQ,
-					ObjectIdGetDatum(loid));
+		if (max_count > 0)
+			batch_limit = max_count - (int) migrated_count;
+		else
+			batch_limit = 10000;
 
-		scan = systable_beginscan(native_meta, LargeObjectMetadataOidIndexId, true,
-								  NULL, 1, skey);
-		tuple = systable_getnext(scan);
-		if (!HeapTupleIsValid(tuple))
+		/* 1. Collect candidate OIDs */
+		if (strict_from_end_to_start)
+			candidate_oids = lolor_collect_oids_reverse(batch_limit);
+		else
+			candidate_oids = lolor_collect_oids_forward(batch_limit);
+
+		if (candidate_oids == NIL)
+			break;
+
+		/* 2. Lock and migrate each candidate */
+		foreach(lc, candidate_oids)
 		{
+			Oid			loid = lfirst_oid(lc);
+			Relation	native_meta;
+			ScanKeyData skey[1];
+			SysScanDesc scan;
+			HeapTuple	tuple;
+			ItemPointerData ctid;
+			TM_Result	tm_result;
+			TM_FailureData tmfd;
+			TupleTableSlot *slot;
+			LockWaitPolicy wait_policy = skip_locked ? LockWaitSkip : LockWaitBlock;
+
+			CHECK_FOR_INTERRUPTS();
+
+			native_meta = table_open(LargeObjectMetadataRelationId, RowExclusiveLock);
+
+			ScanKeyInit(&skey[0],
+						Anum_pg_largeobject_metadata_oid,
+						BTEqualStrategyNumber, F_OIDEQ,
+						ObjectIdGetDatum(loid));
+
+			scan = systable_beginscan(native_meta, LargeObjectMetadataOidIndexId, true,
+									  NULL, 1, skey);
+			tuple = systable_getnext(scan);
+			if (!HeapTupleIsValid(tuple))
+			{
+				systable_endscan(scan);
+				table_close(native_meta, RowExclusiveLock);
+				continue;
+			}
+
+			ctid = tuple->t_self;
 			systable_endscan(scan);
+
+			slot = table_slot_create(native_meta, NULL);
+			tm_result = table_tuple_lock(native_meta, &ctid,
+										 GetActiveSnapshot(), slot,
+										 GetCurrentCommandId(false),
+										 LockTupleExclusive,
+										 wait_policy, 0, &tmfd);
+			ExecDropSingleTupleTableSlot(slot);
 			table_close(native_meta, RowExclusiveLock);
-			continue;
+
+			if (tm_result != TM_Ok)
+				continue;
+
+			if (oldlo_migrate_one(loid))
+			{
+				migrated_count++;
+				batch_migrated++;
+				if (max_count > 0 && migrated_count >= max_count)
+					break;
+			}
 		}
 
-		ctid = tuple->t_self;
-		systable_endscan(scan);
+		list_free(candidate_oids);
 
-		slot = table_slot_create(native_meta, NULL);
-		tm_result = table_tuple_lock(native_meta, &ctid,
-									 GetActiveSnapshot(), slot,
-									 GetCurrentCommandId(false),
-									 LockTupleExclusive,
-									 wait_policy, 0, &tmfd);
-		ExecDropSingleTupleTableSlot(slot);
-		table_close(native_meta, RowExclusiveLock);
+		/* Stop if no progress was made in this batch (all locked/skipped) */
+		if (batch_migrated == 0)
+			break;
 
-		if (tm_result != TM_Ok)
-			continue;
-
-		if (oldlo_migrate_one(loid))
-		{
-			migrated_count++;
-			if (max_count > 0 && migrated_count >= max_count)
-				break;
-		}
+		if (max_count > 0 && migrated_count >= max_count)
+			break;
 	}
 
 	/* 3. Handle run_vacuum if requested */
 	if (run_vacuum && migrated_count > 0)
 	{
 		VacuumParams params;
+		BufferAccessStrategy bstrategy;
 
 		memset(&params, 0, sizeof(params));
 		params.options = VACOPT_VACUUM;
@@ -856,20 +915,29 @@ lolor_migrate(PG_FUNCTION_ARGS)
 		params.freeze_table_age = -1;
 		params.multixact_freeze_min_age = -1;
 		params.multixact_freeze_table_age = -1;
+#if PG_VERSION_NUM >= 180000
 		params.log_vacuum_min_duration = -1;
+#else
+		params.log_min_duration = -1;
+#endif
+
+		bstrategy = GetAccessStrategy(BAS_VACUUM);
 
 		{
 			Relation vac_lo = table_open(LargeObjectRelationId, ShareUpdateExclusiveLock);
-			table_relation_vacuum(vac_lo, &params, NULL);
+			table_relation_vacuum(vac_lo, &params, bstrategy);
 			table_close(vac_lo, ShareUpdateExclusiveLock);
 		}
 
 		{
 			Relation vac_meta = table_open(LargeObjectMetadataRelationId, ShareUpdateExclusiveLock);
-			table_relation_vacuum(vac_meta, &params, NULL);
+			table_relation_vacuum(vac_meta, &params, bstrategy);
 			table_close(vac_meta, ShareUpdateExclusiveLock);
 		}
+
+		FreeAccessStrategy(bstrategy);
 	}
+
 
 	PG_RETURN_INT64(migrated_count);
 }

--- a/src/oldloutils.c
+++ b/src/oldloutils.c
@@ -497,7 +497,16 @@ oldlo_migrate_one(Oid lobjId)
 	else
 	{
 		struct varlena *acl_copy = PG_DETOAST_DATUM_COPY(aclDatum);
+		Acl		   *acl = (Acl *) acl_copy;
+		int			nmembers;
+		Oid		   *members;
+
 		mvalues[Anum_pg_largeobject_metadata_lomacl - 1] = PointerGetDatum(acl_copy);
+		nmembers = aclmembers(acl, &members);
+		for (int i = 0; i < nmembers; i++)
+			lolor_record_role_dependency(members[i]);
+		if (members)
+			pfree(members);
 	}
 
 	new_meta_tup = heap_form_tuple(RelationGetDescr(lolor_meta), mvalues, mnulls);
@@ -560,10 +569,9 @@ oldlo_migrate_one(Oid lobjId)
 	table_close(native_data, RowExclusiveLock);
 
 	/*
-	 * 4. Record owner dependency on lolor relation.
+	 * 4. Record owner dependency on lolor.pg_largeobject_metadata.
 	 */
-	recordDependencyOnOwner(get_LOLOR_LargeObjectRelationId(),
-							lobjId, ownerId);
+	lolor_record_role_dependency(ownerId);
 
 	/*
 	 * 5. Save comment if any, then drop native object via inv_drop().

--- a/src/oldloutils.c
+++ b/src/oldloutils.c
@@ -19,19 +19,26 @@
 
 #include "access/detoast.h"
 #include "access/genam.h"
+#include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tableam.h"
 #include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_largeobject.h"
 #include "catalog/pg_largeobject_metadata.h"
 #include "commands/comment.h"
+#include "commands/vacuum.h"
+#include "executor/tuptable.h"
 #include "libpq/libpq-fs.h"
 #include "miscadmin.h"
+#include "nodes/lockoptions.h"
+#include "storage/bufmgr.h"
 #include "utils/acl.h"
 #include "utils/fmgroids.h"
+#include "utils/hsearch.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #if PG_VERSION_NUM >= 160000
@@ -42,6 +49,7 @@
 
 static Relation oldlo_heap_r = NULL;
 static Relation oldlo_index_r = NULL;
+
 
 static void oldlo_getdatafield(Form_pg_largeobject tuple,
 							   bytea **pdatafield,
@@ -590,3 +598,279 @@ oldlo_migrate_one(Oid lobjId)
 
 	return true;
 }
+
+/*
+ * Helper: collect OIDs from physical end of pg_catalog.pg_largeobject
+ * backwards to the beginning.
+ */
+static List *
+lolor_collect_oids_reverse(int max_count)
+{
+	Relation	lo_rel;
+	BlockNumber nblocks;
+	BlockNumber blk;
+	List	   *oid_list = NIL;
+	HTAB	   *seen_oids;
+	HASHCTL		ctl;
+	Snapshot	snapshot;
+
+	lo_rel = table_open(LargeObjectRelationId, AccessShareLock);
+	nblocks = RelationGetNumberOfBlocks(lo_rel);
+	if (nblocks == 0)
+	{
+		table_close(lo_rel, AccessShareLock);
+		return NIL;
+	}
+
+	memset(&ctl, 0, sizeof(ctl));
+	ctl.keysize = sizeof(Oid);
+	ctl.entrysize = sizeof(Oid);
+	ctl.hcxt = CurrentMemoryContext;
+	seen_oids = hash_create("lolor_migrate_reverse_oids",
+							1024,
+							&ctl,
+							HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+
+	snapshot = GetActiveSnapshot();
+
+	/* Scan blocks backwards from the last block down to 0 */
+	for (blk = nblocks - 1; blk != InvalidBlockNumber; blk--)
+	{
+		Buffer		buf;
+		Page		page;
+		OffsetNumber maxoff;
+		OffsetNumber off;
+
+		buf = ReadBuffer(lo_rel, blk);
+		LockBuffer(buf, BUFFER_LOCK_SHARE);
+		page = BufferGetPage(buf);
+
+		if (!PageIsNew(page))
+		{
+			maxoff = PageGetMaxOffsetNumber(page);
+			for (off = maxoff; off >= FirstOffsetNumber; off = OffsetNumberPrev(off))
+			{
+				ItemId		itemid = PageGetItemId(page, off);
+
+				if (ItemIdIsNormal(itemid))
+				{
+					HeapTupleHeader tuphdr = (HeapTupleHeader) PageGetItem(page, itemid);
+					HeapTupleData tup;
+
+					tup.t_len = ItemIdGetLength(itemid);
+					ItemPointerSet(&(tup.t_self), blk, off);
+					tup.t_tableOid = LargeObjectRelationId;
+					tup.t_data = tuphdr;
+
+					if (HeapTupleSatisfiesVisibility(&tup, snapshot, buf))
+					{
+						bool		isnull;
+						Datum		d;
+
+						d = heap_getattr(&tup, Anum_pg_largeobject_loid,
+										 RelationGetDescr(lo_rel), &isnull);
+						if (!isnull)
+						{
+							Oid			loid = DatumGetObjectId(d);
+							bool		found;
+
+							hash_search(seen_oids, &loid, HASH_ENTER, &found);
+							if (!found)
+							{
+								oid_list = lappend_oid(oid_list, loid);
+								if (max_count > 0 && list_length(oid_list) >= max_count)
+								{
+									UnlockReleaseBuffer(buf);
+									goto done_scan;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		UnlockReleaseBuffer(buf);
+
+		if (blk == 0)
+			break;
+	}
+
+done_scan:
+	hash_destroy(seen_oids);
+	table_close(lo_rel, AccessShareLock);
+
+	return oid_list;
+}
+
+/*
+ * Helper: collect OIDs in forward catalog order from
+ * pg_catalog.pg_largeobject_metadata.
+ */
+static List *
+lolor_collect_oids_forward(int max_count)
+{
+	Relation	meta_rel;
+	SysScanDesc scan;
+	HeapTuple	tup;
+	List	   *oid_list = NIL;
+
+	meta_rel = table_open(LargeObjectMetadataRelationId, AccessShareLock);
+	scan = systable_beginscan(meta_rel, LargeObjectMetadataOidIndexId, true,
+							  NULL, 0, NULL);
+
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_largeobject_metadata form = (Form_pg_largeobject_metadata) GETSTRUCT(tup);
+		Oid			loid = form->oid;
+
+		oid_list = lappend_oid(oid_list, loid);
+		if (max_count > 0 && list_length(oid_list) >= max_count)
+			break;
+	}
+
+	systable_endscan(scan);
+	table_close(meta_rel, AccessShareLock);
+
+	return oid_list;
+}
+
+/*
+ * lolor_migrate: SQL function to batch-migrate native large objects to lolor.
+ *
+ * Parameters:
+ *   arg0: n (int4, default NULL = all)
+ *   arg1: skip_locked (bool, default true)
+ *   arg2: strict_from_end_to_start (bool, default false)
+ *   arg3: run_vacuum (bool, default false)
+ *
+ * Returns: int64 (number of objects migrated)
+ */
+PG_FUNCTION_INFO_V1(lolor_migrate);
+
+Datum
+lolor_migrate(PG_FUNCTION_ARGS)
+{
+	int			max_count = -1;
+	bool		skip_locked = true;
+	bool		strict_from_end_to_start = false;
+	bool		run_vacuum = false;
+	int64		migrated_count = 0;
+	List	   *candidate_oids = NIL;
+	ListCell   *lc;
+
+	/* Only superusers can migrate large objects */
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("lolor.migrate() requires superuser privileges")));
+
+	if (get_LOLOR_LargeObjectMetadataRelationId() == InvalidOid ||
+		get_LOLOR_LargeObjectRelationId() == InvalidOid)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("lolor extension tables are not accessible")));
+
+	if (PG_NARGS() > 0 && !PG_ARGISNULL(0))
+		max_count = PG_GETARG_INT32(0);
+	if (PG_NARGS() > 1 && !PG_ARGISNULL(1))
+		skip_locked = PG_GETARG_BOOL(1);
+	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
+		strict_from_end_to_start = PG_GETARG_BOOL(2);
+	if (PG_NARGS() > 3 && !PG_ARGISNULL(3))
+		run_vacuum = PG_GETARG_BOOL(3);
+
+	if (max_count == 0)
+		PG_RETURN_INT64(0);
+
+	/* 1. Collect candidate OIDs */
+	if (strict_from_end_to_start)
+		candidate_oids = lolor_collect_oids_reverse(max_count);
+	else
+		candidate_oids = lolor_collect_oids_forward(max_count);
+
+	/* 2. Lock and migrate each candidate */
+	foreach(lc, candidate_oids)
+	{
+		Oid			loid = lfirst_oid(lc);
+		Relation	native_meta;
+		ScanKeyData skey[1];
+		SysScanDesc scan;
+		HeapTuple	tuple;
+		ItemPointerData ctid;
+		TM_Result	tm_result;
+		TM_FailureData tmfd;
+		TupleTableSlot *slot;
+		LockWaitPolicy wait_policy = skip_locked ? LockWaitSkip : LockWaitBlock;
+
+		native_meta = table_open(LargeObjectMetadataRelationId, RowExclusiveLock);
+
+		ScanKeyInit(&skey[0],
+					Anum_pg_largeobject_metadata_oid,
+					BTEqualStrategyNumber, F_OIDEQ,
+					ObjectIdGetDatum(loid));
+
+		scan = systable_beginscan(native_meta, LargeObjectMetadataOidIndexId, true,
+								  NULL, 1, skey);
+		tuple = systable_getnext(scan);
+		if (!HeapTupleIsValid(tuple))
+		{
+			systable_endscan(scan);
+			table_close(native_meta, RowExclusiveLock);
+			continue;
+		}
+
+		ctid = tuple->t_self;
+		systable_endscan(scan);
+
+		slot = table_slot_create(native_meta, NULL);
+		tm_result = table_tuple_lock(native_meta, &ctid,
+									 GetActiveSnapshot(), slot,
+									 GetCurrentCommandId(false),
+									 LockTupleExclusive,
+									 wait_policy, 0, &tmfd);
+		ExecDropSingleTupleTableSlot(slot);
+		table_close(native_meta, RowExclusiveLock);
+
+		if (tm_result != TM_Ok)
+			continue;
+
+		if (oldlo_migrate_one(loid))
+		{
+			migrated_count++;
+			if (max_count > 0 && migrated_count >= max_count)
+				break;
+		}
+	}
+
+	/* 3. Handle run_vacuum if requested */
+	if (run_vacuum && migrated_count > 0)
+	{
+		VacuumParams params;
+
+		memset(&params, 0, sizeof(params));
+		params.options = VACOPT_VACUUM;
+		params.truncate = VACOPTVALUE_ENABLED;
+		params.index_cleanup = VACOPTVALUE_AUTO;
+		params.freeze_min_age = -1;
+		params.freeze_table_age = -1;
+		params.multixact_freeze_min_age = -1;
+		params.multixact_freeze_table_age = -1;
+		params.log_vacuum_min_duration = -1;
+
+		{
+			Relation vac_lo = table_open(LargeObjectRelationId, ShareUpdateExclusiveLock);
+			table_relation_vacuum(vac_lo, &params, NULL);
+			table_close(vac_lo, ShareUpdateExclusiveLock);
+		}
+
+		{
+			Relation vac_meta = table_open(LargeObjectMetadataRelationId, ShareUpdateExclusiveLock);
+			table_relation_vacuum(vac_meta, &params, NULL);
+			table_close(vac_meta, ShareUpdateExclusiveLock);
+		}
+	}
+
+	PG_RETURN_INT64(migrated_count);
+}
+

--- a/src/oldloutils.c
+++ b/src/oldloutils.c
@@ -417,7 +417,7 @@ oldlo_read(LargeObjectDesc *obj_desc, char *buf, int nbytes)
 int
 oldlo_drop(Oid lobjId)
 {
-	oldlo_close_lo_relation(false);
+	oldlo_close_lo_relation(true);
 
 	return inv_drop(lobjId);
 }
@@ -448,7 +448,7 @@ oldlo_migrate_one(Oid lobjId)
 	CatalogIndexState indstate;
 	char	   *comment;
 
-	oldlo_close_lo_relation(false);
+	oldlo_close_lo_relation(true);
 
 	/*
 	 * 1. Read metadata from native catalog.
@@ -578,6 +578,12 @@ oldlo_migrate_one(Oid lobjId)
 	 * 5. Save comment if any, then drop native object via inv_drop().
 	 */
 	comment = GetComment(lobjId, LargeObjectRelationId, 0);
+
+	/*
+	 * Ensure any cached relation references are closed before inv_drop()
+	 * modifies the native catalogs.
+	 */
+	oldlo_close_lo_relation(true);
 
 	inv_drop(lobjId);
 
@@ -766,7 +772,6 @@ lolor_collect_oids_forward(int max_count)
  *   arg0: n (int4, default NULL = all)
  *   arg1: skip_locked (bool, default true)
  *   arg2: strict_from_end_to_start (bool, default false)
- *   arg3: run_vacuum (bool, default false)
  *
  * Returns: int64 (number of objects migrated)
  */
@@ -778,7 +783,6 @@ lolor_migrate(PG_FUNCTION_ARGS)
 	int			max_count = -1;
 	bool		skip_locked = true;
 	bool		strict_from_end_to_start = false;
-	bool		run_vacuum = false;
 	int64		migrated_count = 0;
 	List	   *candidate_oids = NIL;
 	ListCell   *lc;
@@ -807,8 +811,6 @@ lolor_migrate(PG_FUNCTION_ARGS)
 		skip_locked = PG_GETARG_BOOL(1);
 	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
 		strict_from_end_to_start = PG_GETARG_BOOL(2);
-	if (PG_NARGS() > 3 && !PG_ARGISNULL(3))
-		run_vacuum = PG_GETARG_BOOL(3);
 
 	if (max_count == 0)
 		PG_RETURN_INT64(0);
@@ -901,44 +903,58 @@ lolor_migrate(PG_FUNCTION_ARGS)
 			break;
 	}
 
-	/* 3. Handle run_vacuum if requested */
-	if (run_vacuum && migrated_count > 0)
-	{
-		VacuumParams params;
-		BufferAccessStrategy bstrategy;
+	PG_RETURN_INT64(migrated_count);
+}
 
-		memset(&params, 0, sizeof(params));
-		params.options = VACOPT_VACUUM;
-		params.truncate = VACOPTVALUE_ENABLED;
-		params.index_cleanup = VACOPTVALUE_AUTO;
-		params.freeze_min_age = -1;
-		params.freeze_table_age = -1;
-		params.multixact_freeze_min_age = -1;
-		params.multixact_freeze_table_age = -1;
+/*
+ * lolor_vacuum_native_storage: SQL function to vacuum native large object catalogs.
+ *
+ * Runs table_relation_vacuum on pg_catalog.pg_largeobject and
+ * pg_catalog.pg_largeobject_metadata. Requires superuser privileges.
+ */
+PG_FUNCTION_INFO_V1(lolor_vacuum_native_storage);
+
+Datum
+lolor_vacuum_native_storage(PG_FUNCTION_ARGS)
+{
+	VacuumParams params;
+	BufferAccessStrategy bstrategy;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to vacuum native large object catalogs")));
+
+	memset(&params, 0, sizeof(params));
+	params.options = VACOPT_VACUUM;
+	params.truncate = VACOPTVALUE_ENABLED;
+	params.index_cleanup = VACOPTVALUE_AUTO;
+	params.freeze_min_age = -1;
+	params.freeze_table_age = -1;
+	params.multixact_freeze_min_age = -1;
+	params.multixact_freeze_table_age = -1;
 #if PG_VERSION_NUM >= 180000
-		params.log_vacuum_min_duration = -1;
+	params.log_vacuum_min_duration = -1;
 #else
-		params.log_min_duration = -1;
+	params.log_min_duration = -1;
 #endif
 
-		bstrategy = GetAccessStrategy(BAS_VACUUM);
+	bstrategy = GetAccessStrategy(BAS_VACUUM);
 
-		{
-			Relation vac_lo = table_open(LargeObjectRelationId, ShareUpdateExclusiveLock);
-			table_relation_vacuum(vac_lo, &params, bstrategy);
-			table_close(vac_lo, ShareUpdateExclusiveLock);
-		}
-
-		{
-			Relation vac_meta = table_open(LargeObjectMetadataRelationId, ShareUpdateExclusiveLock);
-			table_relation_vacuum(vac_meta, &params, bstrategy);
-			table_close(vac_meta, ShareUpdateExclusiveLock);
-		}
-
-		FreeAccessStrategy(bstrategy);
+	{
+		Relation vac_lo = table_open(LargeObjectRelationId, ShareUpdateExclusiveLock);
+		table_relation_vacuum(vac_lo, &params, bstrategy);
+		table_close(vac_lo, NoLock);
 	}
 
+	{
+		Relation vac_meta = table_open(LargeObjectMetadataRelationId, ShareUpdateExclusiveLock);
+		table_relation_vacuum(vac_meta, &params, bstrategy);
+		table_close(vac_meta, NoLock);
+	}
 
-	PG_RETURN_INT64(migrated_count);
+	FreeAccessStrategy(bstrategy);
+
+	PG_RETURN_VOID();
 }
 

--- a/src/oldloutils.c
+++ b/src/oldloutils.c
@@ -1,0 +1,584 @@
+/*-------------------------------------------------------------------------
+ *
+ * oldloutils.c
+ *	  Routines to read and migrate from PostgreSQL native large object
+ *	  storage (pg_catalog.pg_largeobject, pg_catalog.pg_largeobject_metadata).
+ *
+ * Copyright (c) 2022-2026, pgEdge, Inc.
+ * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  contrib/lolor/src/oldloutils.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include <limits.h>
+
+#include "access/detoast.h"
+#include "access/genam.h"
+#include "access/htup_details.h"
+#include "access/sysattr.h"
+#include "access/table.h"
+#include "access/xact.h"
+#include "catalog/dependency.h"
+#include "catalog/indexing.h"
+#include "catalog/pg_largeobject.h"
+#include "catalog/pg_largeobject_metadata.h"
+#include "commands/comment.h"
+#include "libpq/libpq-fs.h"
+#include "miscadmin.h"
+#include "utils/acl.h"
+#include "utils/fmgroids.h"
+#include "utils/rel.h"
+#include "utils/snapmgr.h"
+#if PG_VERSION_NUM >= 160000
+#include "varatt.h"
+#endif
+
+#include "lolor.h"
+
+static Relation oldlo_heap_r = NULL;
+static Relation oldlo_index_r = NULL;
+
+static void oldlo_getdatafield(Form_pg_largeobject tuple,
+							   bytea **pdatafield,
+							   int *plen,
+							   bool *pfreeit);
+
+/*
+ * Open native pg_largeobject and its index, if not already done in current xact.
+ */
+void
+oldlo_open_lo_relation(void)
+{
+	ResourceOwner currentOwner;
+
+	if (oldlo_heap_r && oldlo_index_r)
+		return;
+
+	currentOwner = CurrentResourceOwner;
+	CurrentResourceOwner = TopTransactionResourceOwner;
+
+	if (oldlo_heap_r == NULL)
+		oldlo_heap_r = table_open(LargeObjectRelationId, RowExclusiveLock);
+	if (oldlo_index_r == NULL)
+		oldlo_index_r = index_open(LargeObjectLOidPNIndexId, RowExclusiveLock);
+
+	CurrentResourceOwner = currentOwner;
+}
+
+/*
+ * Clean up native relation references at main transaction end.
+ */
+void
+oldlo_close_lo_relation(bool isCommit)
+{
+	if (oldlo_heap_r || oldlo_index_r)
+	{
+		if (isCommit)
+		{
+			ResourceOwner currentOwner;
+
+			currentOwner = CurrentResourceOwner;
+			CurrentResourceOwner = TopTransactionResourceOwner;
+
+			if (oldlo_index_r)
+				index_close(oldlo_index_r, NoLock);
+			if (oldlo_heap_r)
+				table_close(oldlo_heap_r, NoLock);
+
+			CurrentResourceOwner = currentOwner;
+		}
+		oldlo_heap_r = NULL;
+		oldlo_index_r = NULL;
+	}
+}
+
+/*
+ * Check if a large object exists in native storage with the given snapshot.
+ */
+bool
+oldlo_exists(Oid loid, Snapshot snapshot)
+{
+	Relation	pg_lo_meta;
+	ScanKeyData skey[1];
+	SysScanDesc sd;
+	HeapTuple	tuple;
+	bool		retval = false;
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_largeobject_metadata_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(loid));
+
+	pg_lo_meta = table_open(LargeObjectMetadataRelationId,
+							AccessShareLock);
+
+	sd = systable_beginscan(pg_lo_meta,
+							LargeObjectMetadataOidIndexId, true,
+							snapshot, 1, skey);
+
+	tuple = systable_getnext(sd);
+	if (HeapTupleIsValid(tuple))
+		retval = true;
+
+	systable_endscan(sd);
+
+	table_close(pg_lo_meta, AccessShareLock);
+
+	return retval;
+}
+
+/*
+ * Check access permissions on a native large object.
+ */
+AclResult
+oldlo_aclcheck(Oid loid, Oid roleid, AclMode mode, Snapshot snapshot)
+{
+	return pg_largeobject_aclcheck_snapshot(loid, roleid, mode, snapshot);
+}
+
+/*
+ * Check ownership of a native large object.
+ */
+bool
+oldlo_ownercheck(Oid lobjId, Oid roleid)
+{
+	Relation	rel;
+	ScanKeyData entry[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	bool		isnull;
+	Oid			ownerId;
+
+	if (superuser_arg(roleid))
+		return true;
+
+	rel = table_open(LargeObjectMetadataRelationId, AccessShareLock);
+	ScanKeyInit(&entry[0],
+				Anum_pg_largeobject_metadata_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(lobjId));
+
+	scan = systable_beginscan(rel,
+							  LargeObjectMetadataOidIndexId, true,
+							  NULL, 1, entry);
+
+	tuple = systable_getnext(scan);
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("large object metadata with OID %u does not exist", lobjId)));
+
+	ownerId = DatumGetObjectId(heap_getattr(tuple,
+											Anum_pg_largeobject_metadata_lomowner,
+											RelationGetDescr(rel),
+											&isnull));
+	Assert(!isnull);
+
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return has_privs_of_role(roleid, ownerId);
+}
+
+/*
+ * Extract data field from a native pg_largeobject tuple, detoasting if needed.
+ */
+static void
+oldlo_getdatafield(Form_pg_largeobject tuple,
+				   bytea **pdatafield,
+				   int *plen,
+				   bool *pfreeit)
+{
+	bytea	   *datafield;
+	int			len;
+	bool		freeit;
+
+	datafield = &(tuple->data);
+	freeit = false;
+	if (VARATT_IS_EXTENDED(datafield))
+	{
+		datafield = (bytea *)
+			detoast_attr((struct varlena *) datafield);
+		freeit = true;
+	}
+	len = VARSIZE(datafield) - VARHDRSZ;
+	if (len < 0 || len > LOBLKSIZE)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pg_largeobject entry for OID %u, page %d has invalid data field size %d",
+						tuple->loid, tuple->pageno, len)));
+	*pdatafield = datafield;
+	*plen = len;
+	*pfreeit = freeit;
+}
+
+/*
+ * Determine size of a native large object.
+ */
+uint64
+oldlo_getsize(LargeObjectDesc *obj_desc)
+{
+	uint64		lastbyte = 0;
+	ScanKeyData skey[1];
+	SysScanDesc sd;
+	HeapTuple	tuple;
+
+	Assert(obj_desc);
+
+	oldlo_open_lo_relation();
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_largeobject_loid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(obj_desc->id));
+
+	sd = systable_beginscan_ordered(oldlo_heap_r, oldlo_index_r,
+									obj_desc->snapshot, 1, skey);
+
+	tuple = systable_getnext_ordered(sd, BackwardScanDirection);
+	if (HeapTupleIsValid(tuple))
+	{
+		Form_pg_largeobject data;
+		bytea	   *datafield;
+		int			len;
+		bool		pfreeit;
+
+		if (HeapTupleHasNulls(tuple))
+			elog(ERROR, "null field found in pg_largeobject");
+		data = (Form_pg_largeobject) GETSTRUCT(tuple);
+		oldlo_getdatafield(data, &datafield, &len, &pfreeit);
+		lastbyte = (uint64) data->pageno * LOBLKSIZE + len;
+		if (pfreeit)
+			pfree(datafield);
+	}
+
+	systable_endscan_ordered(sd);
+
+	return lastbyte;
+}
+
+/*
+ * Seek within a native large object.
+ */
+int64
+oldlo_seek(LargeObjectDesc *obj_desc, int64 offset, int whence)
+{
+	int64		newoffset;
+
+	Assert(obj_desc);
+
+	switch (whence)
+	{
+		case SEEK_SET:
+			newoffset = offset;
+			break;
+		case SEEK_CUR:
+			newoffset = obj_desc->offset + offset;
+			break;
+		case SEEK_END:
+			newoffset = oldlo_getsize(obj_desc) + offset;
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid whence setting: %d", whence)));
+			newoffset = 0;
+			break;
+	}
+
+	if (newoffset < 0 || newoffset > MAX_LARGE_OBJECT_SIZE)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg_internal("invalid large object seek target: " INT64_FORMAT,
+								 newoffset)));
+
+	obj_desc->offset = newoffset;
+	return newoffset;
+}
+
+/*
+ * Return current offset within a native large object.
+ */
+int64
+oldlo_tell(LargeObjectDesc *obj_desc)
+{
+	Assert(obj_desc);
+	return obj_desc->offset;
+}
+
+/*
+ * Read from a native large object.
+ */
+int
+oldlo_read(LargeObjectDesc *obj_desc, char *buf, int nbytes)
+{
+	int			nread = 0;
+	int64		n;
+	int64		off;
+	int			len;
+	int32		pageno = (int32) (obj_desc->offset / LOBLKSIZE);
+	uint64		pageoff;
+	ScanKeyData skey[2];
+	SysScanDesc sd;
+	HeapTuple	tuple;
+
+	Assert(obj_desc);
+	Assert(buf != NULL);
+
+	if ((obj_desc->flags & IFS_RDLOCK) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("permission denied for large object %u",
+						obj_desc->id)));
+
+	if (nbytes <= 0)
+		return 0;
+
+	oldlo_open_lo_relation();
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_largeobject_loid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(obj_desc->id));
+
+	ScanKeyInit(&skey[1],
+				Anum_pg_largeobject_pageno,
+				BTGreaterEqualStrategyNumber, F_INT4GE,
+				Int32GetDatum(pageno));
+
+	sd = systable_beginscan_ordered(oldlo_heap_r, oldlo_index_r,
+									obj_desc->snapshot, 2, skey);
+
+	while ((tuple = systable_getnext_ordered(sd, ForwardScanDirection)) != NULL)
+	{
+		Form_pg_largeobject data;
+		bytea	   *datafield;
+		bool		pfreeit;
+
+		if (HeapTupleHasNulls(tuple))
+			elog(ERROR, "null field found in pg_largeobject");
+		data = (Form_pg_largeobject) GETSTRUCT(tuple);
+
+		pageoff = ((uint64) data->pageno) * LOBLKSIZE;
+		if (pageoff > obj_desc->offset)
+		{
+			n = pageoff - obj_desc->offset;
+			n = (n <= (nbytes - nread)) ? n : (nbytes - nread);
+			MemSet(buf + nread, 0, n);
+			nread += n;
+			obj_desc->offset += n;
+		}
+
+		if (nread < nbytes)
+		{
+			Assert(obj_desc->offset >= pageoff);
+			off = (int) (obj_desc->offset - pageoff);
+			Assert(off >= 0 && off < LOBLKSIZE);
+
+			oldlo_getdatafield(data, &datafield, &len, &pfreeit);
+			if (len > off)
+			{
+				n = len - off;
+				n = (n <= (nbytes - nread)) ? n : (nbytes - nread);
+				Assert(n > 0 && n <= nbytes - nread && n <= len - off);
+				memcpy(buf + nread, VARDATA(datafield) + off, n);
+				nread += n;
+				obj_desc->offset += n;
+			}
+			if (pfreeit)
+				pfree(datafield);
+		}
+
+		if (nread >= nbytes)
+			break;
+	}
+
+	systable_endscan_ordered(sd);
+
+	return nread;
+}
+
+/*
+ * Drop a native large object and its dependencies.
+ */
+int
+oldlo_drop(Oid lobjId)
+{
+	ObjectAddress object;
+
+	oldlo_close_lo_relation(false);
+
+	object.classId = LargeObjectRelationId;
+	object.objectId = lobjId;
+	object.objectSubId = 0;
+	performDeletion(&object, DROP_CASCADE, PERFORM_DELETION_SKIP_ORIGINAL);
+
+	LargeObjectDrop(object.objectId);
+
+	CommandCounterIncrement();
+
+	return 1;
+}
+
+/*
+ * Migrate a single large object on-the-fly from native storage to lolor storage.
+ *
+ * Copies metadata and data pages, records owner dependency on lolor relation,
+ * preserves comments if present, and removes the native copy.
+ */
+bool
+oldlo_migrate_one(Oid lobjId)
+{
+	Relation	native_meta;
+	Relation	lolor_meta;
+	Relation	native_data;
+	Relation	lolor_data;
+	ScanKeyData skey[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	Oid			ownerId;
+	Datum		aclDatum;
+	bool		isNull;
+	Datum		mvalues[Natts_pg_largeobject_metadata];
+	bool		mnulls[Natts_pg_largeobject_metadata];
+	HeapTuple	new_meta_tup;
+	CatalogIndexState indstate;
+	char	   *comment;
+
+	oldlo_close_lo_relation(false);
+
+	/*
+	 * 1. Read metadata from native catalog.
+	 */
+	native_meta = table_open(LargeObjectMetadataRelationId, RowExclusiveLock);
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_largeobject_metadata_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(lobjId));
+
+	scan = systable_beginscan(native_meta,
+							  LargeObjectMetadataOidIndexId, true,
+							  NULL, 1, skey);
+
+	tuple = systable_getnext(scan);
+	if (!HeapTupleIsValid(tuple))
+	{
+		systable_endscan(scan);
+		table_close(native_meta, RowExclusiveLock);
+		return false;
+	}
+
+	ownerId = ((Form_pg_largeobject_metadata) GETSTRUCT(tuple))->lomowner;
+	aclDatum = heap_getattr(tuple,
+							Anum_pg_largeobject_metadata_lomacl,
+							RelationGetDescr(native_meta),
+							&isNull);
+
+	/*
+	 * 2. Insert metadata into lolor.pg_largeobject_metadata.
+	 */
+	lolor_meta = table_open(get_LOLOR_LargeObjectMetadataRelationId(), RowExclusiveLock);
+
+	memset(mvalues, 0, sizeof(mvalues));
+	memset(mnulls, false, sizeof(mnulls));
+
+	mvalues[Anum_pg_largeobject_metadata_oid - 1] = ObjectIdGetDatum(lobjId);
+	mvalues[Anum_pg_largeobject_metadata_lomowner - 1] = ObjectIdGetDatum(ownerId);
+	if (isNull)
+	{
+		mnulls[Anum_pg_largeobject_metadata_lomacl - 1] = true;
+	}
+	else
+	{
+		struct varlena *acl_copy = PG_DETOAST_DATUM_COPY(aclDatum);
+		mvalues[Anum_pg_largeobject_metadata_lomacl - 1] = PointerGetDatum(acl_copy);
+	}
+
+	new_meta_tup = heap_form_tuple(RelationGetDescr(lolor_meta), mvalues, mnulls);
+	CatalogTupleInsert(lolor_meta, new_meta_tup);
+	heap_freetuple(new_meta_tup);
+
+	if (!isNull)
+		pfree(DatumGetPointer(mvalues[Anum_pg_largeobject_metadata_lomacl - 1]));
+
+	systable_endscan(scan);
+	table_close(native_meta, RowExclusiveLock);
+	table_close(lolor_meta, RowExclusiveLock);
+
+	/*
+	 * 3. Copy all data pages from native pg_largeobject to lolor.pg_largeobject.
+	 */
+	native_data = table_open(LargeObjectRelationId, RowExclusiveLock);
+	lolor_data = table_open(get_LOLOR_LargeObjectRelationId(), RowExclusiveLock);
+	indstate = CatalogOpenIndexes(lolor_data);
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_largeobject_loid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(lobjId));
+
+	scan = systable_beginscan(native_data,
+							  LargeObjectLOidPNIndexId, true,
+							  NULL, 1, skey);
+
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		Form_pg_largeobject olddata = (Form_pg_largeobject) GETSTRUCT(tuple);
+		bytea	   *datafield;
+		int			len;
+		bool		pfreeit;
+		Datum		dvalues[Natts_pg_largeobject];
+		bool		dnulls[Natts_pg_largeobject];
+		HeapTuple	new_data_tup;
+
+		oldlo_getdatafield(olddata, &datafield, &len, &pfreeit);
+
+		memset(dvalues, 0, sizeof(dvalues));
+		memset(dnulls, false, sizeof(dnulls));
+
+		dvalues[Anum_pg_largeobject_loid - 1] = ObjectIdGetDatum(olddata->loid);
+		dvalues[Anum_pg_largeobject_pageno - 1] = Int32GetDatum(olddata->pageno);
+		dvalues[Anum_pg_largeobject_data - 1] = PointerGetDatum(datafield);
+
+		new_data_tup = heap_form_tuple(RelationGetDescr(lolor_data), dvalues, dnulls);
+		CatalogTupleInsertWithInfo(lolor_data, new_data_tup, indstate);
+		heap_freetuple(new_data_tup);
+
+		if (pfreeit)
+			pfree(datafield);
+	}
+
+	systable_endscan(scan);
+	CatalogCloseIndexes(indstate);
+	table_close(lolor_data, RowExclusiveLock);
+	table_close(native_data, RowExclusiveLock);
+
+	/*
+	 * 4. Record owner dependency on lolor relation.
+	 */
+	recordDependencyOnOwner(get_LOLOR_LargeObjectRelationId(),
+							lobjId, ownerId);
+
+	/*
+	 * 5. Save comment if any, then drop native object via inv_drop().
+	 */
+	comment = GetComment(lobjId, LargeObjectRelationId, 0);
+
+	inv_drop(lobjId);
+
+	if (comment != NULL)
+	{
+		CreateComments(lobjId, LargeObjectRelationId, 0, comment);
+		pfree(comment);
+	}
+
+	CommandCounterIncrement();
+
+	return true;
+}


### PR DESCRIPTION
Hi, here is a first cut pull request for **Zero-Downtime Migration & Utility Command Support for `lolor`**

> [!NOTE]
> My longer-term goal is to get this into something that can be included in core PostgreSQL code to finally be able to remove LO support from core while facilitating easy availability for those who really need it.

> [!WARNING]
> Note that code is mostly generated by Antigravity, so there may be some things that I did not notice in review that need changing. 
> So treat this more as a technology demonstration for discussion than as finished code.

-----------

# Design Doc: Zero-Downtime Migration & Utility Command Support for `lolor`

## Overview

This pull request adds **zero-downtime migration**, **PostgreSQL utility command support** (`ALTER`, `COMMENT`, `GRANT`, `REVOKE`), **shared dependency catalog bloat optimization**, and **incremental batch migration** to `lolor`.

Previously, adopting `lolor` required either taking application downtime or running a monolithic upfront migration (`lolor.migrate_from_native()`) within a single transaction. For databases with millions of large objects or terabytes of data, this risked transaction log exhaustion, replication lag, and heavy lock contention. Furthermore, core PostgreSQL utility commands bypassed `lolor` storage, and standard large object dependency tracking caused severe `pg_shdepend` catalog bloat.

---

## Key Pillars of the Design

### 1. Zero-Downtime Dual-Catalog Access & Transparent Migration

Applications can install and enable `lolor` immediately without running an upfront migration:

- **Transparent Read Fallback**: Read operations (`lo_get`, `lo_get_fragment`, `lo_open(INV_READ)`, `loread`, `lo_lseek`, `lo_tell`) check `lolor.pg_largeobject_metadata`. If the object is not present in `lolor`, it transparently reads directly from PostgreSQL's native catalogs (`pg_catalog.pg_largeobject_metadata` and `pg_catalog.pg_largeobject`). Native descriptors are marked in-memory with `IFS_NATIVE` so no duplicate data is created during reads.
- **Copy-On-Write (On-the-Fly Migration)**: Any write operation on a native large object (`lo_put`, `lo_open(INV_WRITE)`, `lowrite`, `lo_truncate`, `ALTER OWNER`, `GRANT/REVOKE`) atomically copies all chunks and metadata into `lolor` storage and drops the native object via `oldlo_migrate_one()`.
- **Transparent `lo_unlink`**: Unlinking an object that still resides in native storage drops it directly from the native catalog.
- **Collision-Free OID Allocation**: `LOLOR_GetNewOidWithIndex()` checks both `lolor` and native indexes when allocating new OIDs to guarantee no collisions occur during the migration window.
- **Modular Architecture**: All low-level native catalog operations are encapsulated in a dedicated module (`src/oldloutils.c`).

```
                 +--------------------------+
                 | Application Client / SQL |
                 +--------------------------+
                              |
                              v
                   +---------------------+
                   |   lolor API Layer   |
                   +---------------------+
                              |
                Exists in lolor storage?
                   /                    \
                 YES                    NO
                 /                        \
    +------------------------+   Read: Read directly from native
    | lolor.pg_largeobject   |   Write: On-the-fly migrate to lolor,
    | lolor.pg_largeobject_  |          then write to lolor
    |   metadata             |          +----------------------------+
    +------------------------+          | pg_catalog.pg_largeobject  |
                                        | pg_catalog.pg_largeobject_ |
                                        |   metadata                 |
                                        +----------------------------+
```

---

### 2. Utility Command Support via `ProcessUtility_hook`

Core PostgreSQL utility commands check `pg_catalog.pg_largeobject_metadata` directly. To support these operations on `lolor`-managed objects, `lolor` installs a `ProcessUtility_hook` (`src/lolor_utility.c`):

- **`ALTER LARGE OBJECT <oid> OWNER TO <new_owner>`**:
  - Intercepts `AlterOwnerStmt` for `OBJECT_LARGEOBJECT`.
  - Supports explicit role names, `CURRENT_ROLE`, `CURRENT_USER`, and `SESSION_USER`.
  - Migrates native objects on-the-fly if needed, updates `lomowner` in `lolor.pg_largeobject_metadata`, and updates `lomacl` via `aclnewowner()`.
  - Enforces standard ownership permissions and validates role assignment privileges.
- **`COMMENT ON LARGE OBJECT <oid> IS <comment>`**:
  - Intercepts `CommentStmt` for `OBJECT_LARGEOBJECT`.
  - Verifies ownership on `lolor` or native objects.
  - Stores/clears comments in PostgreSQL's canonical comment catalog (`pg_description`, `classoid = LargeObjectRelationId`), maintaining full compatibility with `psql` (`\dd`, `\dl+`).
- **`GRANT / REVOKE { SELECT | UPDATE | ALL } ON LARGE OBJECT <oid>`**:
  - Intercepts `GrantStmt` for `OBJECT_LARGEOBJECT`.
  - Enforces large object privilege masks (`ACL_ALL_RIGHTS_LARGEOBJECT`).
  - Migrates native objects on-the-fly, updates `lomacl` via `aclupdate()`, and produces standard PostgreSQL privilege warnings when appropriate.

---

### 3. Dependency Optimization (`pg_shdepend` Bloat Prevention)

Standard PostgreSQL inserts a shared dependency row in `pg_shdepend` for **every single large object** and its grantees. In databases with millions of objects, this causes massive catalog bloat and stalls `DROP ROLE` and vacuum operations.

- **At Most One Dependency Per Role**: `lolor_record_role_dependency(roleid)` records a shared dependency on `lolor.pg_largeobject_metadata` instead of per-object rows. 10,000,000 large objects for a user result in **1 `pg_shdepend` entry** instead of 10,000,000.
- **Safe Role Deletion Guards**: Core PostgreSQL prevents dropping a role while this single dependency exists.
- **`lolor.cleanup_dependencies() RETURNS integer`**: DBAs can invoke this function on-demand to scan `lolor.pg_largeobject_metadata`. If a role no longer owns any objects or holds any grants, its shared dependency is safely removed, allowing subsequent `DROP ROLE` commands to proceed.

---

### 4. Background Incremental Batch Migration (`lolor.migrate()`)

To migrate large historical datasets in the background without impacting production workloads, `lolor` provides an incremental batch migration function:

```sql
SELECT lolor.migrate(
    n                        => 5000,   -- batch size (NULL = all)
    skip_locked              => true,   -- non-blocking concurrency
    strict_from_end_to_start => true,   -- reverse physical scan for disk truncation
    run_vacuum               => true    -- auto vacuum / truncate after batch
);
```

#### Capabilities:
1. **Bounded Batches (`n`)**: Migrates up to $N$ objects per transaction to keep transactions short and avoid replication lag.
2. **Non-Blocking Concurrency (`skip_locked`)**: Uses `table_tuple_lock` with `LockWaitSkip` on candidate metadata tuples. Multiple background worker processes can run `lolor.migrate()` in parallel without blocking or deadlocking.
3. **Reverse Physical Scan (`strict_from_end_to_start`)**:
   - Standard vacuum cannot truncate a relation file unless the **trailing physical blocks** are empty.
   - Forward or arbitrary migrations empty random blocks ("Swiss cheese"), preventing the operating system from reclaiming disk space until the entire migration is complete.
   - When `strict_from_end_to_start` is enabled, `lolor` reads `pg_catalog.pg_largeobject` backwards from block `N - 1` down to `0` and scans page offsets in reverse. Objects at the physical tail of the relation file are unlinked first.
4. **Automated Vacuuming (`run_vacuum`)**:
   - Calls `table_relation_vacuum` with `VACOPTVALUE_ENABLED` truncation on `pg_catalog.pg_largeobject` and `pg_catalog.pg_largeobject_metadata`, releasing freed physical disk space back to the OS after each batch.

---

## Verification & Test Coverage

The changes are covered by comprehensive regression and TAP tests:
- **`pg_regress` (`sql/lolor.sql`)**:
  - Transparent reading and seeking on native objects.
  - On-the-fly migration upon `lo_put` and `lo_open(INV_WRITE)`.
  - Transparent `lo_unlink` of native objects.
  - `COMMENT ON LARGE OBJECT`: set, update, `IS NULL` removal, and non-existent OID handling.
  - `ALTER LARGE OBJECT ... OWNER TO`: owner modification, native on-the-fly migration, comment preservation through migration.
  - `GRANT` / `REVOKE`: `SELECT`, `UPDATE`, `ALL PRIVILEGES`, warnings, and `lomacl` validation.
  - Dependency protection and `lolor.cleanup_dependencies()` verification with `DROP ROLE`.
  - Incremental batch migration (`lolor.migrate(n)`).
  - Reverse physical heap scan verification (`strict_from_end_to_start`).
  - Vacuum integration verification (`run_vacuum`).
- **TAP Tests (`t/*.pl`)**:
  - All 6 test suites (`001_lolor_basic`, `002_pg_upgrade`, `003_dump_restore`, `004_streaming_replication`, `005_logical_replication`, `006_promote_standby`) pass with zero regressions.